### PR TITLE
add verification for bluesky

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:qcadnb7ezxznfx4wfixjz6ks


### PR DESCRIPTION
aids with https://github.com/kgateway-dev/community/issues/66 - allows us to prove we own kgateway.dev and register that as our Bluesky handle.