### PR TITLE
fixes deprecated resources.PostCSS

### DIFF
--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,7 +1,7 @@
 {{/* CSS */}}
 {{ $options := dict "inlineImports" true "config" "./assets/css/postcss.config.js" }}
 {{ $styles := resources.Get "css/styles.css" }}
-{{ $styles = $styles | resources.PostCSS $options }}
+{{ $styles = $styles | css.PostCSS $options }}
 {{- if hugo.IsProduction }}
 {{ $styles = $styles | minify | fingerprint | resources.PostProcess }}
 <link href="{{ $styles.Permalink }}" rel="stylesheet" integrity="{{ $styles.Data.Integrity }}" />


### PR DESCRIPTION
this one line change should basically allow "hugo server" to work with the latest version of hugo.  otherwise one gets this error message:

```
ERROR deprecated: resources.PostCSS was deprecated in Hugo v0.128.0 and subsequently removed. Use css.PostCSS instead.
```