### PR TITLE
add git hook for dco

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This script automatically adds a Signed-off-by trailer to each commit message, so that your commits
+# will adhere to the DCO (Developer Certificate of Origin) requirements.
+# To use, run `make init-git-hooks` or copy this file to .git/hooks/prepare-commit-msg in your copy of the repo.
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+#----------------------------------------------------------------------------------
+# Repo setup
+#----------------------------------------------------------------------------------
+
+.PHONY: init-git-hooks
+init-git-hooks:  ## Use the tracked version of Git hooks from this repo
+	git config core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 5. Visit http://localhost:1313/
 
 ## Contributing
+
+### General Pull Request Guidelines
+When opening a pull request, each of your commits must contain a `Signed-off-by` trailer to adhere to [DCO](https://developercertificate.org/) requirements. This can be done by one of the following methods:
+- Running `make init-git-hooks` which will configure your repo to use the version-controlled [Git hooks](/.githooks) from this repo (preferred)
+- Manually copying the [.githooks/prepare-commit-msg](/.githooks/prepare-commit-msg) file to `.git/hooks/prepare-commit-msg` in your copy of this repo
+- Making sure to use the `-s` / `--signoff` [flag](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) on each commit
+
 ### Adding a Lab
 1. Add an entry to `data/labs.yaml` with a title, description, and href
 2. Verify that the new lab appears correctly at http://localhost:1313/resources/labs/


### PR DESCRIPTION
Related to https://github.com/kgateway-dev/community/issues/30

Developers can run `make init-git-hooks` to use the `prepare-commit-msg` hook which automatically adds the `Signed-off-by` trailer to all commit messages