### PR TITLE
adds learning paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Refer to the [Documentation Contributor Guide](https://kgateway.dev/docs/referen
 2. Add an entry to `data/videos.yaml` with a description, href, and thumbnailHref. The thumbnailHref should be `/thumbnails/<your-image-name>`
 3. Verify that the new video appears correctly at http://localhost:1313/resources/videos/
 
+### Modifying a learning path
+1. Edit `data/learningpaths.yaml` as appropriate, for example, to add a lab for a specific lesson that doesn't currently reference one
+2. Verify that the change is reflected, by navigating to http://localhost:1313/learn/ and selecting the corresponding learning path.
+
 ### Adding a Blog
 1. Create a new file in `content/blog`. Use the blog title in [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) as the file name.
 2. Fill out the blog with content in [Markdown](https://www.markdownguide.org/tools/hugo/). You can use other blogs as an example of specific styling/features but more details are below.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Refer to the [Documentation Contributor Guide](https://kgateway.dev/docs/referen
 3. Verify that the new video appears correctly at http://localhost:1313/resources/videos/
 
 ### Modifying a learning path
-1. Edit `data/learningpaths.yaml` as appropriate, for example, to add a lab for a specific lesson that doesn't currently reference one
+1. Edit `data/learningpaths.yaml` as appropriate, for example, to add a lab for a specific lesson that doesn't currently reference one.
 2. Verify that the change is reflected, by navigating to http://localhost:1313/learn/ and selecting the corresponding learning path.
 
 ### Adding a Blog

--- a/content/learn/_index.md
+++ b/content/learn/_index.md
@@ -1,0 +1,15 @@
+---
+title: Learning paths
+toc: false
+description: kgateway learning paths
+---
+
+<section class="bg-primary-bg text-white pb-[4.375rem] lg:pb-28 px-4 lg:px-12 xl:px-25 bg-[url(/hero-background.svg)] bg-center bg-no-repeat pt-[9.875rem] lg:pt-50 bg-[length:61.85319rem_60.14119rem] lg:bg-auto">
+  <div class="mx-auto max-w-[1440px] flex flex-row justify-center">
+    <h1 class="text-[2.1875rem] lg:text-[4.0625rem] font-semibold leading-[2.40625rem] lg:leading-[4.46875rem]">
+      Learning paths
+    </h1>
+  </div>
+</section>
+
+{{< learning-paths-list >}}

--- a/content/learn/aigw.md
+++ b/content/learn/aigw.md
@@ -1,0 +1,7 @@
+---
+title: AI Gateway
+toc: false
+description: Discover the AI Gateway capabilities of the kgateway project
+---
+
+{{< learning-path id="aigw" >}}

--- a/content/learn/gwapi.md
+++ b/content/learn/gwapi.md
@@ -1,0 +1,7 @@
+---
+title: Gateway API
+toc: false
+description: Learn the Kubernetes Gateway API with kgateway
+---
+
+{{< learning-path id="gwapi" >}}

--- a/content/learn/kgw.md
+++ b/content/learn/kgw.md
@@ -1,0 +1,7 @@
+---
+title: kgateway topics
+toc: false
+description: Learn features unique to kgateway
+---
+
+{{< learning-path id="kgw" >}}

--- a/data/learningpaths.yaml
+++ b/data/learningpaths.yaml
@@ -1,0 +1,87 @@
+- id: gwapi
+  title: Gateway API
+  description: Learn the Kubernetes Gateway API with kgateway
+  lessons:
+  - title: Introduction to the Gateway API
+    description: Learn about real-world use cases that influenced the development and adoption of the Kubernetes Gateway API
+    blog: introduction-to-kubernetes-gateway-api
+    youtube: kzWgbSTVphs
+  - title: Install kgateway
+    description: Learn to install kgateway
+    blog: guide-to-installing-kgateway
+    youtube: eGo8uJDsBEc
+    lab: install-kgateway-open-source-implementation-of-the-gateway-api
+  - title: Gateway API basics
+    description: Learn to configure Gateway and HTTPRoute resources and expose a service
+    blog: understanding-gateway-api-basics
+    youtube: j89S4tV192g
+    lab: understanding-the-basics-of-kubernetes-gateway-api-with-kgateway
+  - title: Serving HTTPS
+    description: Learn to secure your services with Gateway API and retrofit your configuration to enforce HTTPS traffic
+    blog: configuring-https-routes-gateway-api
+    youtube: cOnL9vjVRvQ
+    lab: configure-https-with-the-gateway-api-and-kgateway
+  - title: Shared gateways
+    description: Learn how to configure a shared gateway for multiple development teams
+    blog: shared-gateways
+    youtube: O3_za6WU_iA
+    lab: configuring-gateways-across-multiple-teams-with-kgateway
+  - title: Routing rules
+    description: Learn HTTP traffic management features including request matching, URL rewriting, traffic splitting and header modification
+    blog: exploring-gateway-api-httproute
+    youtube: CGF3aZXOyxc
+    lab: exploring-httproute-resource-configurations-with-kgateway
+  - title: Service mesh
+    description: Explore how the Gateway API supports, manages and controls internal service mesh traffic
+    blog: supporting-service-mesh-kgateway-gateway-api
+    youtube: c5ZfIUOFb9I
+    lab: gatewayapi-support-for-service-mesh-with-kgateway
+  - title: Policy attachments
+    description: Explore the Gateway API Policy Attachments pattern and learn how policies can extend gateways and routes
+    blog: policy-attachments
+    youtube: NQSADVpcO8M
+    lab: understanding-kgateway-patterns-of-extensions
+  - title: "Canary releases with Argo Rollouts (*)" # missing blog
+    description: Explore how to conduct a canary release with Argo Rollouts and the Gateway API
+    youtube: nI52m7S5gLY
+    lab: understanding-kgateway-patterns-of-extensions
+- id: kgw
+  title: kgateway topics
+  description: Learn features unique to kgateway
+  lessons:
+  - title: "Route delegation (*)" # missing blog
+    description: Explore route delegation in kgateway to enable multi-tenancy, self-service routing, and extended Kubernetes Gateway API capabilities
+    youtube: 5uUGN4Qn_1c
+    lab: route-delegation-in-kgateway
+  - title: Transformations
+    description: Learn how to perform request and response tranformations
+    blog: transformation-in-kgateway
+  - title: "Integration with Istio at ingress (*)" # missing video and lab
+    description: Explore routing requests from Ingress to Istio workloads with mutual TLS
+  - title: "kgateway as a waypoint in Istio (*)" # missing lab
+    description: Learn to use kgateway as a waypoint in your Istio ambient mesh.
+    blog: extend-istio-ambient-kgateway-waypoint
+    youtube: B8oZ1seIDIM
+- id: aigw
+  title: AI Gateway
+  description: Discover the AI Gateway capabilities of the kgateway project
+  lessons:
+  - title: Deploying an AI gateway
+    description: Learn to provision AI gateways for proxying LLMs
+    lab: deploying-kgateway-as-an-ai-gateway
+  - title: LLM Credentials management with AI gateways
+    description: Learn how to manage credentials across LLM providers
+    lab: kgateway-ai-lab-credentials-management
+  - title: Prompt guards
+    description: Learn the fundamentals of ensuring the safety of your LLM content with prompt guards
+    lab: kgateway-ai-lab-prompt-guards
+  - title: Prompt enrichment
+    description: Explore how to manage your system and user prompts in API calls to LLMs
+    lab: kgateway-ai-lab-prompt-enrichment
+  - title: "Model failover (*)" # waiting on fix to kgateway before can add lab
+    description: Learn how to configure failover for calls to LLMs
+  - title: Gateway API Inference extension
+    description: Learn to enable intelligent AI request routing with the Gateway API Inference Extension
+    blog: deep-dive-inference-extensions
+    youtube: 5sAB9_fScMo
+    lab: kgateway-lab-gateway-api-inference-extensions-with-kgateway

--- a/layouts/learn/list.html
+++ b/layouts/learn/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<div class='mx-auto flex bg-white text-primary-dark'>
+    {{ partial "sidebar.html" (dict "context" . "disableSidebar" true) }}
+    <article class="w-full break-words flex justify-center">
+        <main class="w-full relative overflow-hidden">
+            {{ partial "nav.html" }}
+            {{ .Content }}
+        </main>
+    </article>
+</div>
+{{ end }}

--- a/layouts/learn/single.html
+++ b/layouts/learn/single.html
@@ -1,0 +1,24 @@
+{{ define "main" }}
+<script>
+    document.querySelector('html').classList.remove('dark');
+</script>
+<div class='mx-auto flex bg-white text-primary-text'>
+    {{ partial "sidebar.html" (dict "context" . "disableSidebar" true) }}
+    <article class="w-full break-words flex justify-center">
+        <main class="w-full relative overflow-hidden">
+            {{ partial "nav.html" }}
+            <section class="bg-primary-bg text-white pb-[4.375rem] lg:pb-20 px-4 lg:px-12 xl:px-25 bg-[url(/hero-background.svg)] bg-center bg-no-repeat pt-[9.875rem] lg:pt-40 bg-[length:61.85319rem_60.14119rem] lg:bg-auto">
+                <div class="md:px-32 mx-auto max-w-[1440px] flex flex-col justify-center">
+                    <h1 class="text-[2.1875rem] lg:text-[4.0625rem] font-bold leading-[2.40625rem] lg:leading-[4.46875rem] pb-4 text-white">
+                    {{ $.Page.Params.Title }}
+                    </h1>
+                    <p class="text-white">{{ $.Page.Params.Description }}</p>
+                </div>
+            </section>
+            <div class="content px-10 md:px-32 py-8 !text-primary-text max-w-[1440px] mx-auto">
+                {{ .Content }}
+            </div>
+        </main>
+    </article>
+</div>
+{{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -106,6 +106,7 @@
         <div class="dropdown-content rounded-l bg-white absolute">
           <a href="/resources/labs" class="text-primary-text px-4 py-3 block hover:text-primary-bg text-left">Labs</a>
           <a href="/resources/videos" class="text-primary-text px-4 py-3 block hover:text-primary-bg text-left">Videos</a>
+          <a href="/learn" class="text-primary-text px-4 py-3 block hover:text-primary-bg text-left">Learning paths</a>
         </div>
       </div>
       <a class="link whitespace-nowrap text-secondary-link" href="/blog">Blog</a>

--- a/layouts/shortcodes/learning-path.html
+++ b/layouts/shortcodes/learning-path.html
@@ -4,12 +4,9 @@
 {{ if $path }}
 
 <h2>Lessons</h2>
-
-<ul>
-    {{ range $path.lessons }}
-    <li>
-      <b>{{ .title }}</b><br/>
-      {{ .description }}<br/>
+  {{ range $path.lessons }}
+  <h3>{{ .title }}</h3>
+    <p>{{ .description }}.</p>
       <ul>
       {{ if .blog }}
       <li>
@@ -29,7 +26,6 @@
       </ul>
     </li>
     {{ end }}
-</ul>
 
 </div>
 {{ end }}

--- a/layouts/shortcodes/learning-path.html
+++ b/layouts/shortcodes/learning-path.html
@@ -1,0 +1,35 @@
+{{ $id := .Get "id" }}
+{{ $paths := .Site.Data.learningpaths }}
+{{ $path := index (where $paths "id" $id) 0 }}
+{{ if $path }}
+
+<h2>Lessons</h2>
+
+<ul>
+    {{ range $path.lessons }}
+    <li>
+      <b>{{ .title }}</b><br/>
+      {{ .description }}<br/>
+      <ul>
+      {{ if .blog }}
+      <li>
+      <a href="/blog/{{.blog}}">Blog</a><br/>
+      </li>
+      {{ end }}
+      {{ if .youtube }}
+      <li>
+      <a href="https://youtu.be/{{.youtube}}">Video lesson</a><br/>
+      </li>
+      {{ end }}
+      {{ if .lab }}
+      <li>
+      <a href="http://www.solo.io/resources/lab/{{.lab}}?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community">Hands-on Lab</a>
+      </li>
+      {{ end }}
+      </ul>
+    </li>
+    {{ end }}
+</ul>
+
+</div>
+{{ end }}

--- a/layouts/shortcodes/learning-paths-list.html
+++ b/layouts/shortcodes/learning-paths-list.html
@@ -1,0 +1,43 @@
+{{ $data := .Site.Data.learningpaths }}
+<style>
+  html {
+    --s: 12px; /* control the size*/
+    --c1: #6458f4;
+    --c2: #5044e9;
+    
+    --_g: radial-gradient(calc(var(--s)/2),var(--c1) 97%,#0000);
+  }
+
+  .card {
+    background:
+      var(--_g),var(--_g) calc(2*var(--s)) calc(2*var(--s)),
+      repeating-conic-gradient(from 45deg,#0000 0 25%,var(--c2) 0 50%) calc(-.707*var(--s)) calc(-.707*var(--s)),
+      repeating-linear-gradient(135deg,var(--c1) calc(var(--s)/-2) calc(var(--s)/2),var(--c2) 0 calc(2.328*var(--s)));
+    background-size: calc(4*var(--s)) calc(4*var(--s));
+  }
+</style>
+
+{{ $tags := slice }}
+{{ range $data }}
+  {{ $tag := (replace .tag " " "") }}
+  {{ if not (in $tags (dict "tag" $tag "name" .tag)) }}
+    {{ $tags = $tags | append (dict "tag" $tag "name" .tag) }}
+  {{ end }}
+{{ end }}
+
+<section class="px-10 xl:px-20 2xl:px-50 py-[4.375rem] md:py-24 flex flex-col gap-16 justify-center items-center">
+  <div class="grid auto-rows-auto grid-flow-row gap-x-8 gap-y-16 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 justify-items-center">
+    {{ range $data }}
+      <a href="{{ .id }}" class="bg-white rounded-xl py-2 px-4 text-[#6458f4] flex flex-row items-center font-semibold gap-4">
+        <div class='tag-{{ replace .tag " " "" }} card bg-primary-bg min-h-[15.625rem] rounded-[.625rem] flex flex-col items-start w-[24.5rem] p-6 gap-4 justify-between'>
+          <div class="flex flex-col gap-4">
+            <h3 class="font-heading text-2xl text-white font-bold">
+              {{ .title }}
+            </h3>
+            <p class="text-white">{{ .description }}</p>
+          </div>
+        </div>
+      </a>
+    {{ end }}
+  </div>
+</section>


### PR DESCRIPTION
this PR adds learning paths to the kgateway.dev web site - there are three learning paths: k8s gw api learning path, kgateway-specific topics, and ai gateway specific topics.  each page basically suggests a specific order in which to consume the lesson videos and corresponding labs (and blogs).  more like a course.