### PR TITLE
Fix ArgoCD Install Method

### DIFF
--- a/content/docs/operations/install.md
+++ b/content/docs/operations/install.md
@@ -188,8 +188,8 @@ Install the open source kgateway project in your Kubernetes cluster.
        chart: kgateway-crds
        helm:
          skipCrds: false
-       repoURL: oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
-       targetRevision: {{< reuse "docs/versions/n-patch.md" >}}
+       repoURL: cr.kgateway.dev/kgateway-dev/charts
+       targetRevision: v{{< reuse "docs/versions/n-patch.md" >}}
      syncPolicy:
        automated:
          # Prune resources during auto-syncing (default is false)
@@ -220,8 +220,8 @@ Install the open source kgateway project in your Kubernetes cluster.
        chart: kgateway
        helm:
          skipCrds: false
-       repoURL: oci://cr.kgateway.dev/kgateway-dev/charts/kgateway
-       targetRevision: {{< reuse "docs/versions/n-patch.md" >}}
+       repoURL: cr.kgateway.dev/kgateway-dev/charts
+       targetRevision: v{{< reuse "docs/versions/n-patch.md" >}}
      syncPolicy:
        automated:
          # Prune resources during auto-syncing (default is false)


### PR DESCRIPTION
Hi,

This PR fixes two issues in the documentation related to installing kgateway via ArgoCD using an OCI Helm repository.

According to the [ArgoCD Helm documentation](https://argo-cd.readthedocs.io/en/latest/user-guide/helm/#declarative), the `oci://` prefix should not be included in the repoURL field when defining a Helm chart source. Including it leads to repository resolution errors.
The repoURL should point to the repository root, not to the specific chart path. For example:
- ❌ ghcr.io/kgateway-dev/charts/kgateway
- ✅ ghcr.io/kgateway-dev/charts

Additionally, the versions published to the OCI registry by the GitHub Actions pipeline include a `v` prefix (e.g., v1.2.3), so the documentation should reflect that format to avoid version not found errors.

These adjustments align the usage example with the actual behavior of the repository and ArgoCD expectations, reducing confusion for users trying to integrate kgateway via declarative ArgoCD apps.

Let me know if you'd like me to update other related examples.
I found this error when installing kgateway using the ArgoCD method. Let me know if you want feedback on my installation.