### PR TITLE
Docs for CORS

### DIFF
--- a/assets/docs/versions/warn-2-1-only.md
+++ b/assets/docs/versions/warn-2-1-only.md
@@ -1,0 +1,1 @@
+This feature is available in version 2.1.x or later.

--- a/content/docs/operations/upgrade.md
+++ b/content/docs/operations/upgrade.md
@@ -77,6 +77,7 @@ Before you upgrade kgateway, review the following information.
 {{% tab %}}
 1. Decide on the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} version that you want to use. For help, review the [Upgrade Notes in the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} docs](https://gateway-api.sigs.k8s.io/guides/#v12-upgrade-notes). In particular, check if you need to install the experimental channel. The following {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} features require experimental.
    
+   * CORS policies for HTTPRoutes.
    * TCPRoutes to set up a TCP listener on your Gateway.
 
 2. Install the custom resources of the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} version that you want to upgrade to, such as the standard {{< reuse "docs/versions/k8s-gw-version.md" >}} version.

--- a/content/docs/operations/upgrade.md
+++ b/content/docs/operations/upgrade.md
@@ -141,7 +141,7 @@ For Istio upgrades, consult the docs based on the way that you installed Istio. 
 2. Apply the kgateway CRDs for the upgrade version by using Helm.
 
    ```sh
-   helm upgrade -i --namespace kgateway-system --version v{{< reuse "docs/versions/n-patch.md" >}} kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
+   helm upgrade -i --namespace kgateway-system --version v$NEW_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
    ```
 
 3. Make any changes to your Helm values.

--- a/content/docs/security/_index.md
+++ b/content/docs/security/_index.md
@@ -12,6 +12,7 @@ For example, you might use HTTPS listeners for external client connections, enfo
 
 {{< cards >}}
   {{< card link="access-logging" title="Access logging" >}}
+  {{< card link="cors" title="CORS" >}}
   {{< card link="external-auth" title="Bring your own external auth" >}}
   {{< card link="local-ratelimit" title="Local rate limiting" >}}
   {{< card link="backend-tls" title="Backend TLS" >}}

--- a/content/docs/security/cors.md
+++ b/content/docs/security/cors.md
@@ -207,7 +207,10 @@ Now that you have CORS policies applied via an HTTPRoute or TrafficPolicy, you c
    Example output: Notice that the `access-control-expose-headers` value changes depending on the resources that you created.
    * If you created an HTTPRoute with a CORS filter, you see the `Origin` and `X-HTTPRoute-Header` headers.
    * If you created a TrafficPolicy with a CORS filter, you see the `Origin` and `X-TrafficPolicy-Header` headers.
-   
+
+   {{< tabs items="CORS in HTTPRoute,CORS in TrafficPolicy" >}}
+   {{% tab %}}
+
    ```console {hl_lines=[7,8,9]}
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 200 OK
@@ -217,12 +220,30 @@ Now that you have CORS policies applied via an HTTPRoute or TrafficPolicy, you c
    < x-envoy-upstream-service-time: 7
    < access-control-allow-origin: https://example.com
    < access-control-allow-credentials: true
-   < access-control-expose-headers: Origin, X-HTTPRoute-Header, X-TrafficPolicy-Header
+   < access-control-expose-headers: Origin, X-HTTPRoute-Header
    < server: envoy
    < 
    [{"id":1,"name":"Dog","status":"available"},{"id":2,"name":"Cat","status":"pending"}]
    ```
-   
+   {{% /tab %}}
+   {{% tab  %}}
+   ```console {hl_lines=[7,8,9]}
+   * Mark bundle as not supporting multiuse
+   < HTTP/1.1 200 OK
+   < content-type: text/xml
+   < date: Mon, 03 Jun 2024 17:05:31 GMT
+   < content-length: 86
+   < x-envoy-upstream-service-time: 7
+   < access-control-allow-origin: https://example.com
+   < access-control-allow-credentials: true
+   < access-control-expose-headers: Origin, X-TrafficPolicy-Header
+   < server: envoy
+   < 
+   [{"id":1,"name":"Dog","status":"available"},{"id":2,"name":"Cat","status":"pending"}]
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+
 2. Send another request to the Petstore app. This time, you use `notallowed.com` as your origin. Although the request succeeds, you do not get back any CORS headers, because `notallowed.com` is not configured as a supported origin.  
    
    {{< tabs items="LoadBalancer IP address or hostname,Port-forward for local testing" >}}
@@ -257,9 +278,18 @@ Now that you have CORS policies applied via an HTTPRoute or TrafficPolicy, you c
 
 {{< reuse "docs/snippets/cleanup.md" >}}
 
+{{< tabs items="CORS in HTTPRoute,CORS in TrafficPolicy" >}}
+{{% tab %}}
+```sh
+kubectl delete -f https://raw.githubusercontent.com/kgateway-dev/kgateway.dev/refs/heads/{{< reuse "docs/versions/github-branch.md" >}}/assets/docs/examples/petstore.yaml
+kubectl delete httproute petstore-cors -n default
+```
+{{% /tab %}}
+{{% tab  %}}
 ```sh
 kubectl delete -f https://raw.githubusercontent.com/kgateway-dev/kgateway.dev/refs/heads/{{< reuse "docs/versions/github-branch.md" >}}/assets/docs/examples/petstore.yaml
 kubectl delete httproute petstore-cors -n default
 kubectl delete trafficpolicy petstore-cors -n default
 ```
-   
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/docs/security/cors.md
+++ b/content/docs/security/cors.md
@@ -6,6 +6,10 @@ description: Enforce client-site access controls with cross-origin resource shar
 
 Enforce client-site access controls with cross-origin resource sharing (CORS).
 
+{{% callout type="warning" %}} 
+CORS support is available in version 2.1.x or later.
+{{% /callout %}}
+
 ## About CORS
 
 Cross-Origin Resource Sharing (CORS) is a security feature that is implemented by web browsers and that controls how web pages in one domain can request and interact with resources that are hosted on a different domain. By default, web browsers only allow requests to resources that are hosted on the same domain as the web page that served the original request. Access to web pages or resources that are hosted on a different domain is restricted to prevent potential security vulnerabilities, such as cross-site request forgery (CRSF).
@@ -21,13 +25,29 @@ CORS policies are typically implemented to limit access to server resources for 
 * A JavaScript on a web page at `example.com` tries to access a different port, such as `example.com:3001`.
 * A JavaScript on a web page at `https://example.com` tries to access the resources by using a different protocol, such as `http://example.com`.
 
-{{% callout type="info" %}} 
-Some apps, such as `httpbin`, have built-in CORS policies that allow all origins. These policies take precedence over CORS policies that you might configure in kgateway. 
-{{% /callout %}}
+### Configuration options {#options}
+
+You can configure the CORS policy at two levels:
+
+* HTTPRoute: For the native way in Kubernetes Gateway API, configure a CORS policy in the HTTPRoute. The policy is applied to all the routes that are defined in the HTTPRoute.This route-level policy takes precedence over any TrafficPolicy CORS that you might configure. For more information, see the [Kubernetes Gateway API docs](https://gateway-api.sigs.k8s.io/reference/spec/#httpcorsfilter).
+* TrafficPolicy: For more flexibility to reuse the CORS policy across HTTPRoutes, specific routes and Gateways, configure a CORS policy in the TrafficPolicy. For more information about attachment and merging rules, see the [TrafficPolicy concept docs](/docs/about/policies/trafficpolicy/).
+
+<!-- merging?
+
+By default, the configuration of the RouteOption takes precedence over the VirtualHostOption. However, you can change this behavior for the exposeHeaders CORS option by using the corsPolicyMergeSettings field in the VirtualHostOption. Currently, only exposeHeaders is configurable. You cannot merge other CORS options such as allowHeaders or allowOrigin.
+
+For example, you might want to expose the CORS origin header for traffic that reaches any of the gateway listeners with the VirtualHostOption. Additionally, each team or product might have their own headers on a per route basis that you want to expose also, such as product-a. By setting the corsPolicyMergeSettings to UNION, the exposed headers are merged together. This way, both the VirtualHostOption and RouteOption exposeHeaders CORS policies are applied. When the routes are called, the exposed headers from the VirtualHostOption and RouteOption are both returned, such as origin and product-a.
+
+For more information about the supported merge strategies, see the API docs.
+-->
 
 ## Before you begin
 
 {{< reuse "docs/snippets/prereq.md" >}}
+
+{{% callout type="info" %}} 
+Some apps, such as `httpbin`, have built-in CORS policies that allow all origins. These policies take precedence over CORS policies that you might configure in kgateway. 
+{{% /callout %}}
 
 ### Set up your environment to test CORS {#setup-env}
 

--- a/content/docs/traffic-management/transformations/_index.md
+++ b/content/docs/traffic-management/transformations/_index.md
@@ -13,4 +13,4 @@ Mutate and transform requests and responses before forwarding them to the destin
 
 ## Known limitations
 
-**Gateway-level policy in 2.1.x or later**: To apply transformations to all the routes on a Gateway, you must use kgateway version `2.1.0-main` or later. Then, you can select the Gateway in the `targetRefs` field of the TrafficPolicy. Remember that you can configure route-specific transformations by creating another TrafficPolicy with the `targetRefs` field set to the specific HTTPRoute. The HTTPRoute-level policy takes precedence over the Gateway-level policy.
+**Gateway-level policy in 2.1.x or later**: {{< reuse "docs/versions/warn-2-1-only.md" >}} If you use version 2.1 or later, you can select the Gateway in the `targetRefs` field of the TrafficPolicy. Remember that you can configure route-specific transformations by creating another TrafficPolicy with the `targetRefs` field set to the specific HTTPRoute. The HTTPRoute-level policy takes precedence over the Gateway-level policy.


### PR DESCRIPTION
* Docs for CORS https://github.com/kgateway-dev/kgateway.dev/issues/220
* Warning for 2.1 or later (only found CORS and a Gateway-level note for transformation policies)