### PR TITLE
Fix summary sentence

### DIFF
--- a/content/docs/about/custom-resources.md
+++ b/content/docs/about/custom-resources.md
@@ -64,7 +64,7 @@ To learn more about the default gateway setup and how these resource interact wi
 
 ### Policies
 
-While the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} allows you to do simple routing, such as to match, redirect, or rewrite requests, you might want additional capabilities in your API gateway, such as access logging or transformations. [Policies](/docs/about/policies/overview/) allow you to apply intelligent traffic management, resiliency, and security standards to HTTPRoutes or Gateways.
+While the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} allows you to do simple routing, such as to match, redirect, or rewrite requests, you might want additional capabilities in your API gateway, such as access logging or transformations. [Policies](/docs/about/policies/) allow you to apply intelligent traffic management, resiliency, and security standards to HTTPRoutes or Gateways.
 
 Kgateway uses the following custom resources to attach policies to routes and gateway listeners: 
 

--- a/content/docs/traffic-management/route-delegation/_index.md
+++ b/content/docs/traffic-management/route-delegation/_index.md
@@ -3,7 +3,7 @@ title: Route delegation
 weight: 60
 ---
 
-Change the host header or prefix path in requests. 
+Manage routing rules more effectively by using multiple connected HTTPRoute resources.
 
 {{< cards >}}
   {{< card link="overview" title="Route delegation overview" >}}


### PR DESCRIPTION
The route delegation page has the summary sentence from the rewrite page. 

Signed-off-by: Craig Box <craig.box@gmail.com>

/kind documentation

```release-note
NONE
```
