### PR TITLE
Fix doc issue for Backend Routing section

### DIFF
--- a/content/docs/traffic-management/destination-types/backends/_index.md
+++ b/content/docs/traffic-management/destination-types/backends/_index.md
@@ -20,7 +20,7 @@ Check out the following guides for examples on how to use the supported Backends
 You can route to a Backend by simply referencing that Backend in the `backendRefs` section of your HTTPRoute resource as shown in the following example. Note that if your Backend and HTTPRoute resources exist in different namespaces, you must create a Kubernetes ReferenceGrant resource to allow the HTTPRoute to access the Backend.
 
 {{< callout type="warning" >}}
-Do not specify a port in the `spec.backendRefs.port` field when referencing your Backend. The port is defined in your Backend resource and ignored if set on the HTTPRoute resource.
+Do not specify a port in the `spec.backendRefs.port` field when referencing your Backend. The port is defined in your Backend resource and if the port is defined it gives the error `Reason:BackendNotFound` if set on the HTTPRoute resource.
 {{< /callout >}}
 
 ```yaml {linenos=table,hl_lines=[13,14,15,16],linenostart=1,filename="backend-httproute.yaml"}

--- a/content/docs/traffic-management/destination-types/backends/_index.md
+++ b/content/docs/traffic-management/destination-types/backends/_index.md
@@ -20,7 +20,7 @@ Check out the following guides for examples on how to use the supported Backends
 You can route to a Backend by simply referencing that Backend in the `backendRefs` section of your HTTPRoute resource as shown in the following example. Note that if your Backend and HTTPRoute resources exist in different namespaces, you must create a Kubernetes ReferenceGrant resource to allow the HTTPRoute to access the Backend.
 
 {{< callout type="warning" >}}
-Do not specify a port in the `spec.backendRefs.port` field when referencing your Backend. The port is defined in your Backend resource and if the port is defined it gives the error `Reason:BackendNotFound` if set on the HTTPRoute resource.
+Do not specify a port in the `spec.backendRefs.port` field when referencing your Backend. The port is defined in your Backend resource instead. If port is set on the HTTPRoute resource, the status returns a `Reason:BackendNotFound` message.
 {{< /callout >}}
 
 ```yaml {linenos=table,hl_lines=[13,14,15,16],linenostart=1,filename="backend-httproute.yaml"}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Motivation: Fix docs for the functionality that was being wrongly addressed in the docs
Closes Issue #311 
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind documentation
# Changelog
Do not specify a port in the spec.backendRefs.port field when referencing your Backend. The port is defined in your Backend resource and if the port is defined it gives the error Reason:BackendNotFound if set on the HTTPRoute resource.
<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
