### PR TITLE
docs: clarify behavior of backendRefs.port to prevent BackendNotFound

### DIFF
--- a/content/docs/traffic-management/destination-types/backends/_index.md
+++ b/content/docs/traffic-management/destination-types/backends/_index.md
@@ -4,15 +4,15 @@ weight: 20
 prev: /docs/traffic-management/destination-types/kube-services
 ---
 
-Use a Backend resource to define a backing destination that you want kgateway to route to. A Backend destination is external to the cluster and, as such, cannot be represented as a Kubernetes Service. For more information, see the [Backend API docs](/docs/reference/api/#backend). 
+Use a Backend resource to define a backing destination that you want kgateway to route to. A Backend destination is external to the cluster and, as such, cannot be represented as a Kubernetes Service. For more information, see the [Backend API docs](/docs/reference/api/#backend).
 
 ## Types
 
-Check out the following guides for examples on how to use the supported Backends types with kgateway. 
+Check out the following guides for examples on how to use the supported Backends types with kgateway.
 
 {{< cards >}}
-  {{< card link="static" title="Static IP address or hostname" >}}
-  {{< card link="lambda" title="AWS Lambda" >}}
+{{< card link="static" title="Static IP address or hostname" >}}
+{{< card link="lambda" title="AWS Lambda" >}}
 {{< /cards >}}
 
 ## Routing
@@ -20,8 +20,9 @@ Check out the following guides for examples on how to use the supported Backends
 You can route to a Backend by simply referencing that Backend in the `backendRefs` section of your HTTPRoute resource as shown in the following example. Note that if your Backend and HTTPRoute resources exist in different namespaces, you must create a Kubernetes ReferenceGrant resource to allow the HTTPRoute to access the Backend.
 
 {{< callout type="warning" >}}
-Do not specify a port in the `spec.backendRefs.port` field when referencing your Backend. The port is defined in your Backend resource and ignored if set on the HTTPRoute resource.
-{{< /callout >}}
+
+- Avoid specifying a port in the `spec.backendRefs.port` field when referencing a Backend. Although the port is defined in the Backend resource, explicitly setting it in the HTTPRoute may lead to a `BackendNotFound` condition. To prevent misconfiguration, rely solely on the port defined within the Backend specification.
+  {{< /callout >}}
 
 ```yaml {linenos=table,hl_lines=[13,14,15,16],linenostart=1,filename="backend-httproute.yaml"}
 apiVersion: gateway.networking.k8s.io/v1
@@ -31,20 +32,20 @@ metadata:
   namespace: default
 spec:
   parentRefs:
-  - name: http
-    namespace: kgateway-system
+    - name: http
+      namespace: kgateway-system
   hostnames:
     - static.example
-     rules:
-       - backendRefs:
-         - name: json-backend
-           kind: Backend
-           group: gateway.kgateway.dev
-         filters:
-         - type: URLRewrite
-           urlRewrite:
-             hostname: jsonplaceholder.typicode.com
+  rules:
+    - backendRefs:
+      - name: json-backend
+        kind: Backend
+        group: gateway.kgateway.dev
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: jsonplaceholder.typicode.com
    EOF
 ```
 
-For an example, see the [Static](/docs/traffic-management/destination-types/backends/static/) Backend guide. 
+For an example, see the [Static](/docs/traffic-management/destination-types/backends/static/) Backend guide.


### PR DESCRIPTION
### What this PR does

Fixes misleading documentation about the behavior of `spec.backendRefs.port` in `HTTPRoute`.

### Issue reference

Closes #311

### Details

The current documentation suggests that the port defined in HTTPRoute is ignored when referencing a Backend. However, this can result in a `BackendNotFound` condition. This PR updates the warning message to clarify that only the Backend resource should define the port to prevent misconfiguration.

### Checklist

- [x] Documentation updated
- [ ] Tests (not needed for this change)
