### PR TITLE
add trailing slash to redirs

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -3,4 +3,5 @@
 # Redirect old MCP documentation to new Agent Gateway documentation
 /docs/mcp /docs/agentgateway 301
 /docs/integrations/agentgateway /docs/agentgateway 301
- 
+/docs/mcp/ /docs/agentgateway/ 301
+/docs/integrations/agentgateway/ /docs/agentgateway/ 301


### PR DESCRIPTION
- FUP to #341
- wasn't redirecting if the slash was included in the url
```
/kind documentation
```