### PR TITLE
Update operation guides links to be relative

### DIFF
--- a/content/docs/operations/debug.md
+++ b/content/docs/operations/debug.md
@@ -36,7 +36,7 @@ Use built-in tools to troubleshoot issues in your {{< reuse "/docs/snippets/kgat
    ```shell
    kubectl get pods -n {{< reuse "docs/snippets/namespace.md" >}}
    ```
-   <!-- TODO: CLI You can do that by using the `{{< reuse "docs/snippets/cli-name.md" >}} check` [command](/docs/reference/cli/glooctl_check/) that quickly checks the health of kgateway deployments, pods, and custom resources, and verifies Gloo resource configuration. Any issues that are found are reported back in the CLI output. 
+   <!-- TODO: CLI You can do that by using the `{{< reuse "docs/snippets/cli-name.md" >}} check` [command](../../reference/cli/glooctl_check/) that quickly checks the health of kgateway deployments, pods, and custom resources, and verifies Gloo resource configuration. Any issues that are found are reported back in the CLI output. 
    ```sh
    {{< reuse "docs/snippets/cli-name.md" >}} check
    ```
@@ -220,13 +220,13 @@ You can set the log level for the Envoy proxy to get more detailed logs. Envoy l
 
 As part of debugging, you might have noticed that your HTTPRoute or Gateway had an attached TrafficPolicy. The TrafficPolicy's status might say `Accepted` and seem normal. However, when you checked the gateway configuration, the policy is not applied to the selected routes. Review the following common reasons for missing policies.
 
-1. Verify that the TrafficPolicy is attached correctly. For example, you might use label selectors that do not match any HTTPRoute or Gateway. For more information, see [Policy attachment](/docs/about/policies/trafficpolicy/#policy-attachment-trafficpolicy).
+1. Verify that the TrafficPolicy is attached correctly. For example, you might use label selectors that do not match any HTTPRoute or Gateway. For more information, see [Policy attachment](../../about/policies/trafficpolicy/#policy-attachment-trafficpolicy).
 
-2. Confirm that you do not have multiple, conflicting policies. In general, the oldest policy is enforced. For more information, see [Policy priority and merging rules](/docs/about/policies/trafficpolicy/#policy-priority-and-merging-rules).
+2. Confirm that you do not have multiple, conflicting policies. In general, the oldest policy is enforced. For more information, see [Policy priority and merging rules](../../about/policies/trafficpolicy/#policy-priority-and-merging-rules).
 
 3. Determine if you need a [Kubernetes ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/). For example, the TrafficPolicy might rely on a GatewayExtension to enable a feature such as external auth. However, the GatewayExtension might be in a different namespace than the backing external auth service.
 
-   Example ReferenceGrant for [external auth](/docs/security/external-auth/) GatewayExtension:
+   Example ReferenceGrant for [external auth](../../security/external-auth/) GatewayExtension:
 
    * The GrantExtension for external auth, HTTPRoute, and backing Service are in the app namespace, such as `httpbin`.
    * The external auth service is in the `{{< reuse "docs/snippets/namespace.md" >}}` namespace.

--- a/content/docs/operations/install.md
+++ b/content/docs/operations/install.md
@@ -23,7 +23,7 @@ The guide includes steps to install {{< reuse "/docs/snippets/kgateway.md" >}} i
 ## Before you begin
 
 {{< callout type="warning" >}}
-{{< reuse "docs/snippets/one-install.md" >}} If you already tried out {{< reuse "/docs/snippets/kgateway.md" >}} by following the [Get started](/docs/quickstart/) guide, first [uninstall your installation](/docs/operations/uninstall/).
+{{< reuse "docs/snippets/one-install.md" >}} If you already tried out {{< reuse "/docs/snippets/kgateway.md" >}} by following the [Get started](../../quickstart/) guide, first [uninstall your installation](../uninstall/).
 {{< /callout >}}
 
 {{< tabs tabTotal="2" items="Helm,Argo CD" >}}
@@ -88,7 +88,7 @@ Install {{< reuse "/docs/snippets/kgateway.md" >}} by using Helm.
    customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io created
    ```
    
-   {{< callout type="info" >}}If you need to use an experimental feature such as TCPRoutes, install the experimental CRDs. For more information, see [Experimental features in Gateway API](/docs/reference/versions/#experimental-features).{{< /callout >}}
+   {{< callout type="info" >}}If you need to use an experimental feature such as TCPRoutes, install the experimental CRDs. For more information, see [Experimental features in Gateway API](../../reference/versions/#experimental-features).{{< /callout >}}
 
 2. Apply the {{< reuse "/docs/snippets/kgateway.md" >}} CRDs for the upgrade version by using Helm.
 
@@ -196,7 +196,7 @@ Install {{< reuse "/docs/snippets/kgateway.md" >}} by using Argo CD.
    customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io created
    ```
    
-   {{< callout type="info" >}}If you need to use an experimental feature such as TCPRoutes, install the experimental CRDs. For more information, see [Experimental features in Gateway API](/docs/reference/versions/#experimental-features).{{< /callout >}}
+   {{< callout type="info" >}}If you need to use an experimental feature such as TCPRoutes, install the experimental CRDs. For more information, see [Experimental features in Gateway API](../../reference/versions/#experimental-features).{{< /callout >}}
    
 2. Port-forward the Argo CD server on port 9999.
    
@@ -371,11 +371,11 @@ discoveryNamespaceSelectors:
 ## Next steps
 
 Now that you have {{< reuse "/docs/snippets/kgateway.md" >}} set up and running, check out the following guides to expand your API gateway capabilities.
-- Learn more about [{{< reuse "/docs/snippets/kgateway.md" >}}, its features and benefits](/docs/about/overview). 
-- [Deploy an API gateway and sample app](/docs/operations/sample-app/) to test out routing to an app.
-- Add routing capabilities to your httpbin route by using the [Traffic management](/docs/traffic-management) guides. 
-- Explore ways to make your routes more resilient by using the [Resiliency](/docs/resiliency) guides. 
-- Secure your routes with external authentication and rate limiting policies by using the [Security](/docs/security) guides. 
+- Learn more about [{{< reuse "/docs/snippets/kgateway.md" >}}, its features and benefits](../../about/overview). 
+- [Deploy an API gateway and sample app](../sample-app/) to test out routing to an app.
+- Add routing capabilities to your httpbin route by using the [Traffic management](../../traffic-management) guides. 
+- Explore ways to make your routes more resilient by using the [Resiliency](../../resiliency) guides. 
+- Secure your routes with external authentication and rate limiting policies by using the [Security](../../security) guides. 
 
 ## Cleanup
 
@@ -383,8 +383,8 @@ Now that you have {{< reuse "/docs/snippets/kgateway.md" >}} set up and running,
 
 {{< tabs tabTotal="2" items="Helm,Argo CD" >}}
   
-  {{% tab tabName="Helm" %}}Follow the [Uninstall guide](/docs/operations/uninstall).{{% /tab %}}
+  {{% tab tabName="Helm" %}}Follow the [Uninstall guide](../uninstall).{{% /tab %}}
   
-  {{% tab tabName="Argo CD" %}}Follow the [Uninstall with Argo CD guide](/docs/operations/uninstall#argocd).{{% /tab %}}
+  {{% tab tabName="Argo CD" %}}Follow the [Uninstall with Argo CD guide](../uninstall#argocd).{{% /tab %}}
 
 {{< /tabs >}}

--- a/content/docs/operations/sample-app.md
+++ b/content/docs/operations/sample-app.md
@@ -20,7 +20,7 @@ flowchart LR
 
 ## Before you begin
 
-Set up {{< reuse "/docs/snippets/kgateway.md" >}} by following the [Quick start](/docs/quickstart/) or [Installation](/docs/operations/install/) guides.
+Set up {{< reuse "/docs/snippets/kgateway.md" >}} by following the [Quick start](../../quickstart/) or [Installation](../install/) guides.
 
 ## Deploy a sample app {#deploy-app}
 
@@ -285,9 +285,9 @@ Now that your httpbin app is running and exposed on the gateway proxy, you can s
 
 Now that you have {{< reuse "/docs/snippets/kgateway.md" >}} set up and running, check out the following guides to expand your API gateway capabilities.
 
-- Add routing capabilities to your httpbin route by using the [Traffic management](/docs/traffic-management) guides. 
-- Explore ways to make your routes more resilient by using the [Resiliency](/docs/resiliency) guides. 
-- Secure your routes with external authentication and rate limiting policies by using the [Security](/docs/security) guides.
+- Add routing capabilities to your httpbin route by using the [Traffic management](../../traffic-management) guides. 
+- Explore ways to make your routes more resilient by using the [Resiliency](../../resiliency) guides. 
+- Secure your routes with external authentication and rate limiting policies by using the [Security](../../security) guides.
 
 ## Cleanup
 

--- a/content/docs/operations/upgrade.md
+++ b/content/docs/operations/upgrade.md
@@ -32,7 +32,7 @@ During the upgrade, pods that run the new version of the control plane and proxi
    3. Then, you can repeat the steps in this guide to upgrade to the latest patch of the next minor version.
 
 2. Check that your underlying infrastructure platform, such as Kubernetes, and other dependencies run supported versions for the kgateway version that you want to upgrade to.
-   1. Review the [supported versions](/docs/reference/versions/) for dependencies such as Kubernetes, Istio, Helm, and more.
+   1. Review the [supported versions](../../reference/versions/) for dependencies such as Kubernetes, Istio, Helm, and more.
    2. Compare the supported version against the versions that you currently use. 
    3. If necessary, upgrade your dependencies, such as consulting your cluster infrastructure provider to upgrade the version of Kubernetes that your cluster runs.
 
@@ -71,14 +71,14 @@ Before you upgrade {{< reuse "/docs/snippets/kgateway.md" >}}, review the follow
 
 1. Review the [kgateway release notes](https://github.com/kgateway-dev/kgateway/releases) for any breaking changes or new features that you need to be aware of.
 
-2. Check the [supported version compatibility matrix](/docs/reference/versions/#supported-versions). If the version of {{< reuse "/docs/snippets/kgateway.md" >}} that you are upgrading to requires a different version of Kubernetes, the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}}, or Istio, upgrade those technologies accordingly.
+2. Check the [supported version compatibility matrix](../../reference/versions/#supported-versions). If the version of {{< reuse "/docs/snippets/kgateway.md" >}} that you are upgrading to requires a different version of Kubernetes, the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}}, or Istio, upgrade those technologies accordingly.
 
    {{< tabs tabTotal="3" items="Kubernetes Gateway API, Kubernetes, Istio" >}}
 {{% tab tabName="Kubernetes Gateway API" %}}
 1. Decide on the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} version that you want to use. 
 
    * For help, review the [Upgrade Notes in the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} docs for each version](https://gateway-api.sigs.k8s.io/guides/#v12-upgrade-notes).
-   * Check if you need to install the [experimental channel for the features that you want to use](/docs/reference/versions/#experimental-features).
+   * Check if you need to install the [experimental channel for the features that you want to use](../../reference/versions/#experimental-features).
 
 2. Install the custom resources of the {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} version that you want to upgrade to, such as the standard {{< reuse "docs/versions/k8s-gw-version.md" >}} version.
    


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

In the operations doc guides, update the relative path links (e.g., `(/docs/reference/)`) to be dot-notation directory paths instead (e.g., `(../../reference/)`) for easier import link mapping

# Change Type

/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
