### PR TITLE
Doc fixes for agw MCP and BackendTLSPolicy

### DIFF
--- a/content/docs/about/policies/trafficpolicy.md
+++ b/content/docs/about/policies/trafficpolicy.md
@@ -70,6 +70,10 @@ spec:
 
 Instead of applying the policy to all routes that are defined in an HTTPRoute resource, you can apply them to specific routes by using the `ExtensionRef` filter in the HTTPRoute resource. 
 
+{{< callout type="warning" >}}
+Attaching via the `ExtensionRef` filter is legacy behavior and might be be deprecated in a future release. Instead, use the [HTTPRoute rule attachment option](#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later. Also, the `ExtensionRef` filter is not supported for agentgateway proxies.
+{{< /callout >}}
+
 The following example shows a {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that defines a transformation rule. Note that the `spec.targetRef` field is not set. Because of that, the {{< reuse "docs/snippets/trafficpolicy.md" >}} does not apply until it is referenced in an HTTPRoute by using the `ExtensionRef` filter. 
 
 ```yaml

--- a/content/docs/about/policies/trafficpolicy.md
+++ b/content/docs/about/policies/trafficpolicy.md
@@ -71,7 +71,7 @@ spec:
 Instead of applying the policy to all routes that are defined in an HTTPRoute resource, you can apply them to specific routes by using the `ExtensionRef` filter in the HTTPRoute resource. 
 
 {{< callout type="warning" >}}
-Attaching via the `ExtensionRef` filter is legacy behavior and might be be deprecated in a future release. Instead, use the [HTTPRoute rule attachment option](#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later. Also, the `ExtensionRef` filter is not supported for agentgateway proxies.
+Attaching a policy via the `ExtensionRef` filter is legacy behavior and might be deprecated in a future release. Instead, use the [HTTPRoute rule attachment option](#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later. Also, the `ExtensionRef` filter is not supported for agentgateway proxies.
 {{< /callout >}}
 
 The following example shows a {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that defines a transformation rule. Note that the `spec.targetRef` field is not set. Because of that, the {{< reuse "docs/snippets/trafficpolicy.md" >}} does not apply until it is referenced in an HTTPRoute by using the `ExtensionRef` filter. 

--- a/content/docs/agentgateway/about.md
+++ b/content/docs/agentgateway/about.md
@@ -45,3 +45,11 @@ helm upgrade -i -n {{< reuse "docs/snippets/namespace.md" >}} {{< reuse "/docs/s
      --set agentGateway.enabled=true \
      --version {{< reuse "docs/versions/helm-version-upgrade.md" >}}
 ```
+
+## More considerations
+
+Review the following considerations for using agentgateway.
+
+- Attaching TrafficPolicies to particular routes via the `ExtensionRef` filter is not supported. Instead, use the [HTTPRoute rule attachment option](../about/policies/trafficpolicy/#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later.
+- HTTPListenerPolicy and BackendConfigPolicy that configure Envoy-specific filters in the kgateway proxy are not supported. This impacts topics that are kgateway proxy-specific, such as health checks and access logging.
+- External processing as part of TrafficPolicy is not supported.

--- a/content/docs/agentgateway/about.md
+++ b/content/docs/agentgateway/about.md
@@ -51,5 +51,5 @@ helm upgrade -i -n {{< reuse "docs/snippets/namespace.md" >}} {{< reuse "/docs/s
 Review the following considerations for using agentgateway.
 
 - Attaching TrafficPolicies to particular routes via the `ExtensionRef` filter is not supported. Instead, use the [HTTPRoute rule attachment option](../about/policies/trafficpolicy/#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later.
-- HTTPListenerPolicy and BackendConfigPolicy that configure Envoy-specific filters in the kgateway proxy are not supported. This impacts topics that are kgateway proxy-specific, such as health checks and access logging.
-- External processing as part of TrafficPolicy is not supported.
+- HTTPListenerPolicy and BackendConfigPolicy resources that configure Envoy-specific filters, such as health checks and access logging, cannot be applied to agentgateway proxies. You can use these policies with Envoy-based kgateway proxies only. 
+- External processing (extProc) as part of the TrafficPolicy is not supported.

--- a/content/docs/agentgateway/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/mcp/dynamic-mcp.md
@@ -18,8 +18,8 @@ Note that only streamable HTTP is currently supported for label selectors. If yo
 Deploy an MCP server that you want agentgateway to proxy traffic to. The following example sets up an MCP server that provides various utility tools.
 
 1. Create an MCP server (`mcp-server`) that provides various utility tools. Notice the following details about the Service:
-   * Required `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
-   * Optional `kgateway.dev/mcp-path` annotation. The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
+   * `appProtocol: kgateway.dev/mcp` (required): Configure your service to use the MCP protocol. This way, the agentgateway proxy uses the MCP protocol when connecting to the service.
+   * `kgateway.dev/mcp-path` annotation (optional): The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
 
    ```yaml
    kubectl apply -f- <<EOF
@@ -87,7 +87,7 @@ Deploy an MCP server that you want agentgateway to proxy traffic to. The followi
    ```
 
    {{< callout type="info" >}}
-   Plan to attach policies to your selector-based Backend later? You can still attach the policy to a particular backing Service. To do so, set the `targetRef` setting to the backing Service, not the service selector. Include the `sectionName` of the port that you want the policy to apply to. For an example, check out the [BackendTLSPolicy guide](../../../security/backend-tls/).
+   Plan to attach policies to your selector-based Backend later? You can still attach the policy to a particular backing Service. To do so, set the `targetRef` setting in the policy to the backing Service, not to the Backend's service selector. Include the `sectionName` of the port that you want the policy to apply to. For an example, check out the [BackendTLSPolicy guide](../../../security/backend-tls/).
    {{< /callout >}}
 
 ## Step 2: Route with agentgateway {#agentgateway}

--- a/content/docs/agentgateway/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/mcp/dynamic-mcp.md
@@ -76,8 +76,9 @@ Deploy an MCP server that you want agentgateway to proxy traffic to. The followi
      mcp:
        name: mcp-virtual-server
        targets:
-         - selectors:
-             serviceSelector:
+         - name: mcp-server-everything
+           selector:
+             service:
                matchLabels:
                  app: mcp-server-everything
    EOF

--- a/content/docs/agentgateway/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/mcp/dynamic-mcp.md
@@ -17,7 +17,7 @@ Note that only streamable HTTP is currently supported for label selectors. If yo
 
 Deploy an MCP server that you want agentgateway to proxy traffic to. The following example sets up an MCP server that provides various utility tools.
 
-1. Create an MCP server (`mcp-server`) that provides various utility tools.Notice the following details about the Service:
+1. Create an MCP server (`mcp-server`) that provides various utility tools. Notice the following details about the Service:
    * Required `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
    * Optional `kgateway.dev/mcp-path` annotation. The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
 
@@ -87,7 +87,7 @@ Deploy an MCP server that you want agentgateway to proxy traffic to. The followi
    ```
 
    {{< callout type="info" >}}
-   Plan to attach policies to your selector-based Backend later? You can still target the policy to a particular backing Service. To do so, set the `targetRef` to backing Service, not the service selector. Include the `sectionName` of the port that you want the policy to apply to. For an example, check out the [BackendTLSPolicy guide](../../../security/backend-tls/).
+   Plan to attach policies to your selector-based Backend later? You can still attach the policy to a particular backing Service. To do so, set the `targetRef` setting to the backing Service, not the service selector. Include the `sectionName` of the port that you want the policy to apply to. For an example, check out the [BackendTLSPolicy guide](../../../security/backend-tls/).
    {{< /callout >}}
 
 ## Step 2: Route with agentgateway {#agentgateway}

--- a/content/docs/agentgateway/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/mcp/dynamic-mcp.md
@@ -17,7 +17,9 @@ Note that only streamable HTTP is currently supported for label selectors. If yo
 
 Deploy an MCP server that you want agentgateway to proxy traffic to. The following example sets up an MCP server that provides various utility tools.
 
-1. Create an MCP server (`mcp-server`) that provides various utility tools. Notice that the Service uses the `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
+1. Create an MCP server (`mcp-server`) that provides various utility tools.Notice the following details about the Service:
+   * Required `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
+   * Optional `kgateway.dev/mcp-path` annotation. The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
 
    ```yaml
    kubectl apply -f- <<EOF
@@ -63,7 +65,7 @@ Deploy an MCP server that you want agentgateway to proxy traffic to. The followi
    EOF
    ```
 
-2. Create a Backend for your MCP server that uses label selectors to select the MCP server. 
+2. Create a Backend for your MCP server that uses label selectors to select the MCP server.
 
    ```yaml
    kubectl apply -f- <<EOF
@@ -83,6 +85,10 @@ Deploy an MCP server that you want agentgateway to proxy traffic to. The followi
                  app: mcp-server-everything
    EOF
    ```
+
+   {{< callout type="info" >}}
+   Plan to attach policies to your selector-based Backend later? You can still target the policy to a particular backing Service. To do so, set the `targetRef` to backing Service, not the service selector. Include the `sectionName` of the port that you want the policy to apply to. For an example, check out the [BackendTLSPolicy guide](../../../security/backend-tls/).
+   {{< /callout >}}
 
 ## Step 2: Route with agentgateway {#agentgateway}
 

--- a/content/docs/agentgateway/mcp/static-mcp.md
+++ b/content/docs/agentgateway/mcp/static-mcp.md
@@ -13,7 +13,9 @@ Route to a Model Context Protocol (MCP) server through a static address. For mor
 
 Deploy a Model Context Protocol (MCP) server that you want agentgateway to proxy traffic to. The following example sets up a simple MCP server with one tool, `fetch`, that retrieves the content of a website URL that you pass in.
 
-1. Create the MCP server workload. Notice that the Service uses the `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
+1. Create the MCP server workload. Notice the following details about the Service:
+   * Required `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
+   * Optional `kgateway.dev/mcp-path` annotation. The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
 
    ```yaml
    kubectl apply -f- <<EOF
@@ -64,8 +66,8 @@ Deploy a Model Context Protocol (MCP) server that you want agentgateway to proxy
      mcp:
        name: mcp-server
        targets:
-       - static:
-           name: mcp-target
+       - name: mcp-target
+         static:
            host: mcp-website-fetcher.default.svc.cluster.local
            port: 80
            protocol: SSE   

--- a/content/docs/agentgateway/mcp/static-mcp.md
+++ b/content/docs/agentgateway/mcp/static-mcp.md
@@ -14,8 +14,8 @@ Route to a Model Context Protocol (MCP) server through a static address. For mor
 Deploy a Model Context Protocol (MCP) server that you want agentgateway to proxy traffic to. The following example sets up a simple MCP server with one tool, `fetch`, that retrieves the content of a website URL that you pass in.
 
 1. Create the MCP server workload. Notice the following details about the Service:
-   * Required `appProtocol: kgateway.dev/mcp` setting. This way, the agentgateway proxy uses the MCP protocol for the service.
-   * Optional `kgateway.dev/mcp-path` annotation. The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
+   * `appProtocol: kgateway.dev/mcp` (required): Configure your service to use the MCP protocol. This way, the agentgateway proxy uses the MCP protocol when connecting to the service.
+   * `kgateway.dev/mcp-path` annotation (optional): The default values are `/sse` for the SSE protocol or `/mcp` for the Streamable HTTP protocol. If you need to change the path of the MCP target endpoint, set this annotation on the Service.
 
    ```yaml
    kubectl apply -f- <<EOF

--- a/content/docs/reference/versions.md
+++ b/content/docs/reference/versions.md
@@ -84,6 +84,7 @@ The following features are experimental in the upstream Kubernetes Gateway API p
 | [CORS policies](/docs/security/cors/) | 1.2 |
 | [Retries](/docs/resiliency/retries/) | 1.2 |
 | [Session persistence](/docs/traffic-management/session-affinity/session-persistence) | 1.3 | 
+| [HTTPRoute rule attachment option](/docs/about/policies/trafficpolicy/#attach-to-rule) | 1.3 |
 
 **Sample command for version {{< reuse "docs/versions/k8s-gw-version.md" >}}**: Note that some CRDs are prefixed with `X` to indicate that the entire CRD is experimental and subject to change.
      

--- a/content/docs/security/backend-tls.md
+++ b/content/docs/security/backend-tls.md
@@ -40,7 +40,7 @@ The following example uses an NGINX server with a self-signed TLS certificate. F
 1. Deploy the NGINX server with a self-signed TLS certificate.
 
    ```shell
-   kubectl apply -f https://raw.githubusercontent.com/kgateway-dev/kgateway/refs/heads/main/test/kubernetes/e2e/features/backendtls/inputs/nginx.yaml
+   kubectl apply -f https://raw.githubusercontent.com/kgateway-dev/kgateway/refs/heads/main/test/kubernetes/e2e/features/backendtls/testdata/nginx.yaml
    ```
 
 2. Verify that the NGINX server is running.
@@ -64,7 +64,7 @@ Create the BackendTLSPolicy for the NGINX workload. For more information, see th
 
    ```shell
    kubectl apply -f- <<EOF
-   {{< github url="https://raw.githubusercontent.com/kgateway-dev/kgateway/refs/heads/main/test/kubernetes/e2e/features/backendtls/inputs/configmap.yaml" >}}
+   {{< github url="https://raw.githubusercontent.com/kgateway-dev/kgateway/refs/heads/main/test/kubernetes/e2e/features/backendtls/testdata/configmap.yaml" >}}
    EOF
    ```
 
@@ -83,6 +83,7 @@ Create the BackendTLSPolicy for the NGINX workload. For more information, see th
      - group: ""
        kind: Service
        name: nginx
+       sectionName: "8443"
      validation:
        hostname: "example.com"
        caCertificateRefs:
@@ -96,7 +97,7 @@ Create the BackendTLSPolicy for the NGINX workload. For more information, see th
 
    | Setting | Description |
    |---------|-------------|
-   | `targetRefs` | The service that you want the Gateway to originate a TLS connection to, such as the NGINX server. |
+   | `targetRefs` | The service that you want the Gateway to originate a TLS connection to, such as the NGINX server. <br><br>{{< icon name="agentgateway" >}}**Agentgateway proxies**: Even if you use a Backend for selector-based destinations, you still need to target the backing Service and the `sectionName` of the port that you want the policy to apply to.  |
    | `validation.hostname` | The hostname that matches the NGINX server certificate. |
    | `validation.caCertificateRefs` | The ConfigMap that has the public CA certificate for the NGINX server. |
 

--- a/content/docs/security/backend-tls.md
+++ b/content/docs/security/backend-tls.md
@@ -10,10 +10,6 @@ Originate a one-way TLS connection from the Gateway to a backend.
 {{< reuse "docs/versions/warn-experimental.md" >}}
 {{< /callout >}}
 
-{{< callout >}}
-{{< reuse "docs/snippets/proxy-kgateway.md" >}}
-{{< /callout >}}
-
 ## About one-way TLS
 
 When you configure a TLS listener on your Gateway, the Gateway typically terminates incoming TLS traffic and forwards the unencrypted traffic to the backend service. However, you might have a service that only accepts TLS connections, or you want to forward traffic a secured Backend service that is external to the cluster.


### PR DESCRIPTION
# Description
extensionRef note
- legacy behavior
- does not work with agentgateway
- update MCP static and dynamic examples
- add details to BackendTLSPolicy attachment
- see https://github.com/kgateway-dev/kgateway/pull/12148#discussion_r2310082574

# Change Type

```
/kind documentation
```

# Changelog

```release-note
NONE
```