### PR TITLE
Add external k8s gw api links to auto-generation

### DIFF
--- a/scripts/crd-ref-docs-config.yaml
+++ b/scripts/crd-ref-docs-config.yaml
@@ -25,3 +25,20 @@ render:
     - name: TypeMeta
       package: k8s.io/apimachinery/pkg/apis/meta/v1
       link: https://kubernetes.io/docs/reference/generated/kubernetes-api/v${KUBE_VERSION}/#typemeta-v1-meta
+    
+    # Gateway API types
+    - name: BackendRef
+      package: sigs.k8s.io/gateway-api/apis/v1
+      link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.BackendRef
+    - name: BackendObjectReference
+      package: sigs.k8s.io/gateway-api/apis/v1
+      link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.BackendObjectReference
+    - name: ParentReference
+      package: sigs.k8s.io/gateway-api/apis/v1
+      link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference
+    - name: GRPCBackendRef
+      package: sigs.k8s.io/gateway-api/apis/v1
+      link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCBackendRef
+    - name: HTTPBackendRef
+      package: sigs.k8s.io/gateway-api/apis/v1
+      link: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPBackendRef


### PR DESCRIPTION
# Description

URLs to K8s GW API weren't added to the generated docs. 

# Change Type
```
/kind bug_fix
/kind cleanup
/kind documentation
```

# Changelog


```release-note
NONE
```

# Additional Notes
cc @Nadine2016 @artberger 