### PR TITLE
route delegation limitation in agw

### DIFF
--- a/content/docs/main/traffic-management/route-delegation/_index.md
+++ b/content/docs/main/traffic-management/route-delegation/_index.md
@@ -5,6 +5,10 @@ weight: 20
 
 Manage routing rules more effectively by using multiple connected HTTPRoute resources.
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 {{< cards >}}
   {{< card link="overview" title="Route delegation overview" >}}
   {{< card link="basic" title="Basic example" >}}

--- a/content/docs/main/traffic-management/route-delegation/basic.md
+++ b/content/docs/main/traffic-management/route-delegation/basic.md
@@ -6,6 +6,10 @@ description: Set up basic route delegation between a parent and two child HTTPRo
 
 Set up basic route delegation between a parent and two child HTTPRoute resources.
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 ## Configuration overview
 
 In this guide you walk through a basic route delegation example that demonstrates route delegation between a parent HTTPRoute resource and two child HTTPRoute resources that forward traffic to an httpbin sample app. The following image illustrates the resulting route delegation hierarchy:

--- a/content/docs/main/traffic-management/route-delegation/header-query.md
+++ b/content/docs/main/traffic-management/route-delegation/header-query.md
@@ -6,6 +6,10 @@ description: Use header and query matchers in a route delegation setup.
 
 Use header and query matchers in a route delegation setup. 
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 ## Configuration overview
 
 In this guide you walk through a route delegation example where headers and query parameters are added as matchers to the parent and child HTTPRoute resources. A routing hierarchy can be created only if the child defines the same header and query matchers that the parent HTTPResource defines. You can optionally define additional header or query matchers on the child HTTPRoute resource.

--- a/content/docs/main/traffic-management/route-delegation/inheritance/_index.md
+++ b/content/docs/main/traffic-management/route-delegation/inheritance/_index.md
@@ -7,6 +7,10 @@ description:
 
 Learn how policies can be inherited or overridden along the delegation chain: 
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 {{< cards >}}
   {{< card link="native-policies" title="Native Gateway API policies" >}}
   {{< card link="kgateway-policies" title="Kgateway policies" >}}

--- a/content/docs/main/traffic-management/route-delegation/label.md
+++ b/content/docs/main/traffic-management/route-delegation/label.md
@@ -9,6 +9,10 @@ description: Use labels to delegate traffic from a parent HTTPRoute to different
 {{< reuse "docs/versions/warn-2-1-only.md" >}} 
 {{< /callout >}}
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 In this example, you learn how to use labels to delegate traffic. The parent HTTPRoute defines the labels that must be present on the child HTTPRoute to allow traffic to be forwarded. 
 
 You typically configure the parent to find an HTTPRoute with a specific label in a specific namespace. However, you can also use a wildcard for the namespace when you have multiple HTTPRoutes in different namespaces that can all receive delegated traffic. This configuration can significantly simplify your route delegation setup, as it allows you to quickly add new child HTTPRoutes to the delegation chain without changing the parent HTTPRoute configuration. 

--- a/content/docs/main/traffic-management/route-delegation/multi-level-delegation.md
+++ b/content/docs/main/traffic-management/route-delegation/multi-level-delegation.md
@@ -6,6 +6,10 @@ description: Create a 3-level route delegation hierarchy with a parent, child, a
 
 Create a 3-level route delegation hierarchy with a parent, child, and grandchild HTTPRoute resource.
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 ## Configuration overview
 
 In this guide you walk through a route delegation example that demonstrates route delegation from a parent HTTPRoute resource to a child HTTPRoute resource, and from a child HTTPRoute resource to a grandchild HTTPRoute resource. The following image illustrates the route delegation hierarchy:

--- a/content/docs/main/traffic-management/route-delegation/multi-parent.md
+++ b/content/docs/main/traffic-management/route-delegation/multi-parent.md
@@ -6,6 +6,10 @@ description: Set up route delegation for a child HTTPRoute resource that can rec
 
 Set up route delegation for a child HTTPRoute resource that can receive traffic from one or more parent HTTPRoute resources.
 
+{{< callout >}}
+{{< reuse "docs/snippets/proxy-kgateway.md" >}}
+{{< /callout >}}
+
 ## Configuration overview
 
 In this guide you walk through a route delegation example that demonstrates route delegation between two parent HTTPRoute and two child HTTPRoute resources that forward traffic to an httpbin sample app. The following image illustrates the route delegation hierarchy:


### PR DESCRIPTION
# Description

- route delegation not currently supported for agw proxy

# Change Type

```
/kind documentation
```

# Changelog


```release-note
NONE
```
