### PR TITLE
Add kgateway v2.1 release blog

### DIFF
--- a/content/blog/kgateway v2.1 release blog.md
+++ b/content/blog/kgateway v2.1 release blog.md
@@ -44,11 +44,11 @@ spec:
 EOF
 ```
 
-You are now ready to try out agentgateway. Check out the [agentgateway guides](/docs/latest/agentgateway/) to learn how to route traffic to an LLM provider, MCP tool server, or agent. 
+You are now ready to try out agentgateway. Check out the [agentgateway guides](/docs/latest/agentgateway/) to learn how to route traffic to an LLM provider, MCP tool server, or AI agent. 
 
-### K8s GW API 1.3.0 and Inference Extension 1.0
+### K8s GW API 1.3.0 and Inference Extension 1.0.0
 
-Kgateway is now fully conformant with the Kubernetes Gateway API version 1.3.0 and Inference Extension version 1.0. To learn more, check out the conformance test reports: 
+Kgateway is now fully conformant with the Kubernetes Gateway API version 1.3.0 and Inference Extension version 1.0.0. To learn more, check out the conformance test reports: 
 
 * [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports/v1.3.0/kgateway)
 * [Inference Extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/conformance/reports/v1.0.0/gateway/kgateway)


### PR DESCRIPTION
# Release Blog for kgateway v2.1

This pull request adds the blog post for the latest kgateway v2.1 from Realease notes: 
- https://kgateway.dev/docs/main/reference/release-notes/
- https://github.com/kgateway-dev/kgateway.dev/pull/422/files

The blog post highlights key new and enhanced features:
- agentgateway
- HPA
- DFP
- outlier detection
- session affinity
- kgateway operations dashboard
- leader election