### PR TITLE
Change extAuth 'enablement' to 'disable: {}'

### DIFF
--- a/content/docs/main/security/external-auth.md
+++ b/content/docs/main/security/external-auth.md
@@ -288,7 +288,7 @@ You can apply a policy at two levels: the Gateway level or the HTTPRoute level. 
        kind: HTTPRoute
        name: httpbin
      extAuth:
-       enablement: DisableAll
+       disable: {}
    EOF
    ```
 


### PR DESCRIPTION
Updated external authorization configuration to use 'disable: {}' instead of 'DisableAll'.

# Description

The TrafficPolicy manifest provided in the documentation for ExternalAuth failed to apply to the cluster. I was getting a strict decoding error because the spec.extAuth.enablement field is not recognized by the API, as issue raised in #420 

## Change Type

/kind documentation 
/kind bug

## Changelog

The change updates the example configuration to use the correct field for disabling authentication.

* In this HTTPRoute example, replaces `enablement: DisableAll` with `disable: {}` to reflect the correct configuration for disabling external authentication.