### PR TITLE
Bump docs to 2.0.5

### DIFF
--- a/assets/docs/versions/n-patch.md
+++ b/assets/docs/versions/n-patch.md
@@ -1,1 +1,1 @@
-{{< version include-if="2.2.x" >}}2.2.0-main{{< /version >}}{{< version include-if="2.1.x" >}}2.1.0{{< /version >}}{{< version include-if="2.0.x" >}}2.0.4{{< /version >}}
+{{< version include-if="2.2.x" >}}2.2.0-main{{< /version >}}{{< version include-if="2.1.x" >}}2.1.0{{< /version >}}{{< version include-if="2.0.x" >}}2.0.5{{< /version >}}

--- a/assets/docs/versions/patch_n-1.md
+++ b/assets/docs/versions/patch_n-1.md
@@ -1,1 +1,1 @@
-{{< version include-if="2.2.x" >}}2.1.0{{< /version >}}{{< version include-if="2.1.x" >}}2.0.4{{< /version >}}{{< version include-if="2.0.x" >}}2.0.3{{< /version >}}
+{{< version include-if="2.2.x" >}}2.1.0{{< /version >}}{{< version include-if="2.1.x" >}}2.0.5{{< /version >}}{{< version include-if="2.0.x" >}}2.0.3{{< /version >}}


### PR DESCRIPTION
Bump docs for 2.0.5 release

# Change Type
/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```
