### PR TITLE
docs: remove trailing newline for `reuse` shortcode

### DIFF
--- a/layouts/shortcodes/reuse.html
+++ b/layouts/shortcodes/reuse.html
@@ -17,6 +17,6 @@
 {{- end }}
 
 {{- /* Render resource content. */}}
-{{- $r.Content | .Page.RenderString }}
+{{- $r.Content | .Page.RenderString | chomp }}
 
 {{- /* Chomp trailing newlines. */ -}}


### PR DESCRIPTION
# Description

**Motivation:** The `reuse` shortcode was rendering content with trailing newlines, which could cause unwanted line break in the final HTML output.

**What changed:** Added the `chomp` filter to the content rendering pipeline in `layouts/shortcodes/reuse.html` to remove trailing newlines from the rendered content.

# Change Type

/kind documentation

# Changelog

```release-note
NONE
```

# Additional Notes

This render issue can be found in:
- https://kgateway.dev/docs/2.0.x/quickstart/#install
- https://kgateway.dev/docs/2.0.x/reference/helm/#download
