### PR TITLE
Ref doc workflow: Add API doc post processing for malformed structs

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -196,7 +196,7 @@ jobs:
               subprocess.run(['sed', '-i', 's/Optional: {}/Optional/g', f'content/docs/{url_path}/reference/api.md'], check=True)
               subprocess.run(['sed', '-i', '/^# API Reference$/,/^$/d', f'content/docs/{url_path}/reference/api.md'], check=True)
               
-              # Additional post-processing to clean up complex struct types and YAML formatting
+              # Additional post-processing to clean up complex struct types
               import re
               api_file = f'content/docs/{url_path}/reference/api.md'
               with open(api_file, 'r') as f:
@@ -223,32 +223,6 @@ jobs:
                   '_Underlying type:_ _struct_',
                   content
               )
-              
-              # Fix YAML code blocks: convert tabs to spaces and remove excessive blank lines
-              def fix_yaml_block(match):
-                  yaml_content = match.group(1)
-                  # Convert tabs to 2 spaces
-                  yaml_content = yaml_content.replace('\t', '  ')
-                  # Remove leading/trailing blank lines
-                  lines = yaml_content.split('\n')
-                  # Remove blank lines at start
-                  while lines and not lines[0].strip():
-                      lines.pop(0)
-                  # Remove blank lines at end
-                  while lines and not lines[-1].strip():
-                      lines.pop()
-                  # Remove excessive consecutive blank lines (keep max 1)
-                  result = []
-                  prev_blank = False
-                  for line in lines:
-                      is_blank = not line.strip()
-                      if is_blank and prev_blank:
-                          continue
-                      result.append(line)
-                      prev_blank = is_blank
-                  return '```yaml\n' + '\n'.join(result) + '\n```'
-              
-              content = re.sub(r'```yaml\n(.*?)```', fix_yaml_block, content, flags=re.DOTALL)
               
               with open(api_file, 'w') as f:
                   f.write(content)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Noticed some breakage in the API docs rendering. For example, this broken struct https://kgateway.dev/docs/envoy/main/reference/api/#agentgatewaypolicybackendsimple:

<img width="851" height="332" alt="Screenshot 2025-12-01 at 12 07 54 PM" src="https://github.com/user-attachments/assets/f19e5f95-a2df-45bb-bdd9-81fb30ba2d67" />

In the API gen workflow, adds some post-processing after the api docs are rendered to cleanup broken struct types.

# Change Type

```
/kind documentation
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
