### PR TITLE
Add menu bar to 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -4,6 +4,12 @@
 {{ end }}
 <!DOCTYPE html>
 <html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 - Page Not Found | kgateway</title>
+  {{- partial "custom/head-end.html" . -}}
+</head>
 
 <script>
     var docsVersions = "{{ $docsVersions }}".slice(1, -1).split(' ');
@@ -24,7 +30,9 @@
 </script>
 
 <body
-    style='font-family:system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"; height:100vh; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center'>
+    style='font-family:system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"; margin: 0; padding-top: 100px;'>
+    {{- partial "nav.html" . -}}
+    <div style="height: calc(100vh - 100px); text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center;">
     <div>
         <style>
             body {
@@ -57,5 +65,4 @@
         </div>
     </div>
 </body>
-
 </html>


### PR DESCRIPTION
# Description

Adds the menu bar to the 404 page.

Currently, it is just a 404, no menu bar or way to navigate off:
<img width="1193" height="566" alt="image" src="https://github.com/user-attachments/assets/5b3b6f6f-df15-4445-837b-e45419cbde09" />

Now, with these changes:
<img width="1696" height="681" alt="image" src="https://github.com/user-attachments/assets/8ec9d5cb-b682-48e7-9d40-63802c7b119e" />


# Change Type

/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
