### PR TITLE
Fix idle "stream" timeout typo

### DIFF
--- a/content/docs/envoy/latest/resiliency/timeouts/idle.md
+++ b/content/docs/envoy/latest/resiliency/timeouts/idle.md
@@ -21,7 +21,7 @@ Note that the idle timeout configures the timeout for the entire connection from
 
 {{< reuse "docs/snippets/prereq.md" >}}
 
-## Set up idle stream timeouts
+## Set up idle timeouts
 
 1. Create an HTTPListenerPolicy with your idle timeout configuration. In this example, you apply an idle timeout of 30 seconds.
 

--- a/content/docs/envoy/main/resiliency/timeouts/idle.md
+++ b/content/docs/envoy/main/resiliency/timeouts/idle.md
@@ -21,7 +21,7 @@ Note that the idle timeout configures the timeout for the entire connection from
 
 {{< reuse "docs/snippets/prereq.md" >}}
 
-## Set up idle stream timeouts
+## Set up idle timeouts
 
 1. Create an HTTPListenerPolicy with your idle timeout configuration. In this example, you apply an idle timeout of 30 seconds.
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Copy-paste typo on idle timeout page - shouldnt have "stream"

# Change Type

```
/kind documentation
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
