### PR TITLE
Fix link path in AI deprecation note

### DIFF
--- a/assets/docs/snippets/ai-deprecation-note.md
+++ b/assets/docs/snippets/ai-deprecation-note.md
@@ -1,3 +1,3 @@
 {{< callout type="warning" >}}
-AI Gateway for Envoy-based gateway proxies is deprecated and is planned to be removed in version 2.2. If you want to use AI capabilities, use an [agentgateway proxy](../../agentgateway/) instead.
+AI Gateway for Envoy-based gateway proxies is deprecated and is planned to be removed in version 2.2. If you want to use AI capabilities, use an [agentgateway proxy](../../../agentgateway/) instead.
 {{< /callout >}}


### PR DESCRIPTION
Currently, the link from https://kgateway.dev/docs/envoy/latest/ai/about/ returns 404
