### PR TITLE
Mention Golang as a pre-req for generating previews

### DIFF
--- a/assets/docs/pages/reference/contribution/preview.md
+++ b/assets/docs/pages/reference/contribution/preview.md
@@ -18,7 +18,9 @@ The kgateway documentation is built by using the static site generator Hugo. As 
    ```sh
    npm install
    ```
-   
+
+4. Install the version of [Golang](https://go.dev/doc/install) used in `go.mod` and make sure `go` is in your `$PATH`.
+
 ## Build the site locally
 
 1. Build the site locally. 
@@ -27,4 +29,3 @@ The kgateway documentation is built by using the static site generator Hugo. As 
    ```
 
 2. Open the site. The local preview is available at [localhost:1313](localhost:1313). 
-

--- a/content/docs/latest/reference/contribution/preview.md
+++ b/content/docs/latest/reference/contribution/preview.md
@@ -23,7 +23,9 @@ The kgateway documentation is built by using the static site generator Hugo. As 
    ```sh
    npm install
    ```
-   
+
+4. Install the version of [Golang](https://go.dev/doc/install) used in `go.mod` and make sure `go` is in your `$PATH`.
+
 ## Build the site locally
 
 1. Build the site locally. 

--- a/content/docs/main/reference/contribution/preview.md
+++ b/content/docs/main/reference/contribution/preview.md
@@ -23,7 +23,9 @@ The kgateway documentation is built by using the static site generator Hugo. As 
    ```sh
    npm install
    ```
-   
+
+4. Install the version of [Golang](https://go.dev/doc/install) used in `go.mod` and make sure `go` is in your `$PATH`.
+
 ## Build the site locally
 
 1. Build the site locally. 


### PR DESCRIPTION
# Description

Mention Golang as a pre-req for generating previews

## before

```
$ hugo server -D
...
goenv: 'go' command not found
...
ERROR command error: failed to load modules: failed to download modules: failed to execute 'go [mod download]': failed to execute binary "go" with args [mod download]: goenv: 'go' command not found
```

## after

```
$ hugo server -D
hugo: collected modules in 1809 msWatching for changes in /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/assets/{blog,css,docs,img}, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/content/{blog,boilerplates,docs,learn,resources}, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/data, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/hugo_stats.json, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/i18n, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/layouts/{_default,blog,docs,learn,partials,...}, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/package.json, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/static/{.well-known,css,integrations,js,learningpaths,...}
Watching for config changes in /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/hugo.yaml, /Users/dxia/src/github.com/kgateway-dev/kgateway.dev/go.mod
Start building sites …
hugo v0.153.2+extended+withdeploy darwin/arm64 BuildDate=2025-12-22T16:53:01Z VendorInfo=Homebrew

                  │  EN
──────────────────┼──────
 Pages            │ 1268
 Paginator pages  │    0
 Non-page files   │   73
 Static files     │   94
 Processed images │    5
 Aliases          │    0
 Cleaned          │    0

Built in 6658 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

```
/kind documentation
```