### PR TITLE
Label K8s resources correctly for easier cleanup

### DIFF
--- a/assets/docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
+++ b/assets/docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
@@ -24,7 +24,7 @@ Deploy a sample gRPC service for testing purposes. The sample service has two AP
 
 Steps to set up the sample gRPC service:
 
-1. Deploy the gRPC echo server and client.
+1. Deploy the gRPC echo server.
 
    ```yaml
    kubectl apply -f - <<EOF
@@ -32,6 +32,9 @@ Steps to set up the sample gRPC service:
    kind: Deployment
    metadata:
      name: grpc-echo
+     namespace: default
+     labels:
+       app: grpc-echo
    spec:
      selector:
        matchLabels:
@@ -66,6 +69,9 @@ Steps to set up the sample gRPC service:
    kind: Service
    metadata:
      name: grpc-echo-svc
+     namespace: default
+     labels:
+       app: grpc-echo
    spec:
      type: ClusterIP
      ports:
@@ -75,18 +81,6 @@ Steps to set up the sample gRPC service:
          appProtocol: kubernetes.io/h2c
      selector:
        app: grpc-echo
-   ---
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: grpcurl-client
-   spec:
-     containers:
-       - name: grpcurl
-         image: docker.io/fullstorydev/grpcurl:v1.8.7-alpine
-         command:
-           - sleep
-           - "infinity"
    EOF
    ```
 
@@ -99,6 +93,8 @@ Steps to set up the sample gRPC service:
    metadata:
      name: allow-grpc-route-to-echo
      namespace: default
+     labels:
+       app: grpc-echo
    spec:
      from:
      - group: gateway.networking.k8s.io
@@ -126,6 +122,9 @@ Create an HTTPS listener so that the gateway can route gRPC traffic. GRPCRoute r
      -n {{< reuse "docs/snippets/namespace.md" >}} \
      --key grpc.example.com.key \
      --cert grpc.example.com.crt
+  
+   kubectl label secret grpc-example-com-cert app=grpc-echo \
+     -n {{< reuse "docs/snippets/namespace.md" >}}
    ```
 
 2. Create a Gateway resource with an HTTPS listener.
@@ -351,7 +350,7 @@ Explore the traffic management, resiliency, and security policies that you can a
 {{< reuse "docs/snippets/cleanup.md" >}}
 
 ```bash
-kubectl delete -A gateways,grpcroutes,pod,svc,secrets -l app=grpc-echo
-kubectl delete referencegrant allow-grpc-route-to-echo -n default
+kubectl delete --all-namespaces \
+  deployments,gateways,grpcroutes,referencegrants,services,secrets \
+  --selector app=grpc-echo
 ```
-

--- a/content/docs/latest/traffic-management/destination-types/kube-services/grpc-services.md
+++ b/content/docs/latest/traffic-management/destination-types/kube-services/grpc-services.md
@@ -31,7 +31,7 @@ Deploy a sample gRPC service for testing purposes. The sample service has two AP
 
 Steps to set up the sample gRPC service:
 
-1. Deploy the gRPC echo server and client.
+1. Deploy the gRPC echo server.
 
    ```yaml
    kubectl apply -f - <<EOF
@@ -39,6 +39,9 @@ Steps to set up the sample gRPC service:
    kind: Deployment
    metadata:
      name: grpc-echo
+     namespace: default
+     labels:
+       app: grpc-echo
    spec:
      selector:
        matchLabels:
@@ -73,6 +76,9 @@ Steps to set up the sample gRPC service:
    kind: Service
    metadata:
      name: grpc-echo-svc
+     namespace: default
+     labels:
+       app: grpc-echo
    spec:
      type: ClusterIP
      ports:
@@ -82,18 +88,6 @@ Steps to set up the sample gRPC service:
          appProtocol: kubernetes.io/h2c
      selector:
        app: grpc-echo
-   ---
-   apiVersion: v1
-   kind: Pod
-   metadata:
-     name: grpcurl-client
-   spec:
-     containers:
-       - name: grpcurl
-         image: docker.io/fullstorydev/grpcurl:v1.8.7-alpine
-         command:
-           - sleep
-           - "infinity"
    EOF
    ```
 
@@ -106,6 +100,8 @@ Steps to set up the sample gRPC service:
    metadata:
      name: allow-grpc-route-to-echo
      namespace: default
+     labels:
+       app: grpc-echo
    spec:
      from:
      - group: gateway.networking.k8s.io
@@ -133,6 +129,9 @@ Create an HTTPS listener so that the gateway can route gRPC traffic. GRPCRoute r
      -n {{< reuse "docs/snippets/namespace.md" >}} \
      --key grpc.example.com.key \
      --cert grpc.example.com.crt
+
+   kubectl label secret grpc-example-com-cert app=grpc-echo \
+     -n {{< reuse "docs/snippets/namespace.md" >}}
    ```
 
 2. Create a Gateway resource with an HTTPS listener.
@@ -358,6 +357,7 @@ Explore the traffic management, resiliency, and security policies that you can a
 {{< reuse "docs/snippets/cleanup.md" >}}
 
 ```bash
-kubectl delete -A gateways,grpcroutes,pod,svc,secrets -l app=grpc-echo
-kubectl delete referencegrant allow-grpc-route-to-echo -n default
+kubectl delete --all-namespaces \
+  deployments,gateways,grpcroutes,referencegrants,services,secrets \
+  --selector app=grpc-echo
 ```


### PR DESCRIPTION
# Description

- **Motivation:** why this change is needed

Use one simplified `kubectl delete` command with long CLI switches for descriptiveness. Also remove the unused gRPC client.

# Change Type

```
/kind documentation
```