### PR TITLE
Fix grammatical error in Gateway API description

### DIFF
--- a/assets/docs/pages/about/overview.md
+++ b/assets/docs/pages/about/overview.md
@@ -66,7 +66,7 @@ Traditionally an ingress primarily handles routing and aggregation, with Kuberne
 
 ### What is the Kubernetes Gateway API?
 
-The {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} is a common, extensible standard for traffic management in Kubernetes. It has quickly becoming the standard interface for defining routing and policy for cloud native networking, addressing many shortcomings of its predecessor, the Ingress API, and unifying best practices that have evolved through real-world usage.
+The {{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} is a common, extensible standard for traffic management in Kubernetes. It is quickly becoming the standard interface for defining routing and policy for cloud native networking, addressing many shortcomings of its predecessor, the Ingress API, and unifying best practices that have evolved through real-world usage.
 
 [Learn about the history of the Gateway API](/blog/introduction-to-kubernetes-gateway-api/), or [watch our in-depth video series](/resources/videos/).
 


### PR DESCRIPTION
# Description

Fix grammatical error in Gateway API description

# Change Type

/kind documentation

# Changelog



```release-note
NONE
```

# Additional Notes

