### PR TITLE
Fix spacing in docs

### DIFF
--- a/assets/docs/pages/agentgateway/about.md
+++ b/assets/docs/pages/agentgateway/about.md
@@ -1,4 +1,4 @@
-{{< reuse "docs/snippets/agentgateway/about.md" >}}
+{{% reuse "docs/snippets/agentgateway/about.md" %}}
 
 Agentgateway supports many agent connectivity use cases, including the following:
 

--- a/content/docs/agentgateway/2.0.x/reference/api.md
+++ b/content/docs/agentgateway/2.0.x/reference/api.md
@@ -3,7 +3,7 @@ title: API reference
 weight: 10
 ---
 
-{{< reuse "/docs/snippets/api-ref-docs-intro.md" >}}
+{{% reuse "/docs/snippets/api-ref-docs-intro.md" %}}
 
 ## Packages
 - [gateway.kgateway.dev/v1alpha1](#gatewaykgatewaydevv1alpha1)

--- a/content/docs/agentgateway/2.0.x/reference/helm/kgateway-crds.md
+++ b/content/docs/agentgateway/2.0.x/reference/helm/kgateway-crds.md
@@ -7,4 +7,4 @@ Review Helm values for the kgateway-crds Helm chart.
 
 This Helm chart controls whether specific sets of CRDs for agentgateway are installed. For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.0.x/kgateway-crds.md" >}}
+{{% reuse "docs/pages/reference/helm/2.0.x/kgateway-crds.md" %}}

--- a/content/docs/agentgateway/2.0.x/reference/helm/kgateway.md
+++ b/content/docs/agentgateway/2.0.x/reference/helm/kgateway.md
@@ -7,4 +7,4 @@ Review Helm values for the kgateway Helm chart.
 
 For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.0.x/kgateway.md" >}}
+{{% reuse "docs/pages/reference/helm/2.0.x/kgateway.md" %}}

--- a/content/docs/agentgateway/latest/about/_index.md
+++ b/content/docs/agentgateway/latest/about/_index.md
@@ -3,9 +3,9 @@ title: About
 weight: 10
 ---
 
-{{< reuse "docs/snippets/agentgateway/about.md" >}}
+{{% reuse "docs/snippets/agentgateway/about.md" %}}
 
-To learn more about {{< reuse "docs/snippets/agentgateway.md" >}}, review the following topics.
+To learn more about {{% reuse "docs/snippets/agentgateway.md" %}}, review the following topics.
 
 {{< cards >}}
   {{< card link="overview" title="Overview" >}}

--- a/content/docs/agentgateway/latest/about/architecture.md
+++ b/content/docs/agentgateway/latest/about/architecture.md
@@ -4,4 +4,4 @@ weight: 15
 
 ---
 
-{{< reuse "docs/pages/about/architecture.md" >}}
+{{% reuse "docs/pages/about/architecture.md" %}}

--- a/content/docs/agentgateway/latest/about/overview.md
+++ b/content/docs/agentgateway/latest/about/overview.md
@@ -3,4 +3,4 @@ title: Overview
 weight: 10
 ---
 
-{{< reuse "docs/pages/agentgateway/about.md" >}}
+{{% reuse "docs/pages/agentgateway/about.md" %}}

--- a/content/docs/agentgateway/latest/agent/a2a.md
+++ b/content/docs/agentgateway/latest/agent/a2a.md
@@ -3,4 +3,4 @@ title: Connect to an agent
 weight: 40
 ---
 
-{{< reuse "docs/pages/agentgateway/agent/a2a.md" >}}
+{{% reuse "docs/pages/agentgateway/agent/a2a.md" %}}

--- a/content/docs/agentgateway/latest/agent/about.md
+++ b/content/docs/agentgateway/latest/agent/about.md
@@ -4,4 +4,4 @@ weight: 10
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/agent/about.md" >}}
+{{% reuse "docs/pages/agentgateway/agent/about.md" %}}

--- a/content/docs/agentgateway/latest/configuration.md
+++ b/content/docs/agentgateway/latest/configuration.md
@@ -4,4 +4,4 @@ weight: 65
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/configuration.md" >}}
+{{% reuse "docs/pages/agentgateway/configuration.md" %}}

--- a/content/docs/agentgateway/latest/inference.md
+++ b/content/docs/agentgateway/latest/inference.md
@@ -4,4 +4,4 @@ weight: 30
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/inference.md" >}}
+{{% reuse "docs/pages/agentgateway/inference.md" %}}

--- a/content/docs/agentgateway/latest/install/_index.md
+++ b/content/docs/agentgateway/latest/install/_index.md
@@ -4,7 +4,7 @@ weight: 14
 icon: settings
 ---
 
-Learn how to install the {{< reuse "/docs/snippets/kgateway.md" >}} {{< gloss "Control Plane" >}}control plane{{< /gloss >}} to use with {{< reuse "/docs/snippets/agentgateway.md" >}} {{< gloss "Data Plane" >}}data plane{{< /gloss >}} proxies.
+Learn how to install the {{% reuse "/docs/snippets/kgateway.md" %}} {{< gloss "Control Plane" >}}control plane{{< /gloss >}} to use with {{% reuse "/docs/snippets/agentgateway.md" %}} {{< gloss "Data Plane" >}}data plane{{< /gloss >}} proxies.
 
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}

--- a/content/docs/agentgateway/latest/install/advanced.md
+++ b/content/docs/agentgateway/latest/install/advanced.md
@@ -4,7 +4,7 @@ weight: 70
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/advanced.md" >}}
+{{% reuse "docs/pages/install/advanced.md" %}}
 
 
 

--- a/content/docs/agentgateway/latest/install/argocd.md
+++ b/content/docs/agentgateway/latest/install/argocd.md
@@ -4,7 +4,7 @@ weight: 10
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/argocd.md" >}}
+{{% reuse "docs/pages/install/argocd.md" %}}
 
 
 

--- a/content/docs/agentgateway/latest/install/helm.md
+++ b/content/docs/agentgateway/latest/install/helm.md
@@ -4,7 +4,7 @@ weight: 5
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/helm.md" >}}
+{{% reuse "docs/pages/install/helm.md" %}}
 
 
 

--- a/content/docs/agentgateway/latest/install/tls.md
+++ b/content/docs/agentgateway/latest/install/tls.md
@@ -3,7 +3,7 @@ title: TLS encryption
 weight: 100
 ---
 
-{{< reuse "docs/pages/install/tls.md" >}}
+{{% reuse "docs/pages/install/tls.md" %}}
 
 
 

--- a/content/docs/agentgateway/latest/llm/about.md
+++ b/content/docs/agentgateway/latest/llm/about.md
@@ -4,4 +4,4 @@ weight: 10
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/about.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/about.md" %}}

--- a/content/docs/agentgateway/latest/llm/api-keys.md
+++ b/content/docs/agentgateway/latest/llm/api-keys.md
@@ -4,4 +4,4 @@ weight: 30
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/api-keys.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/api-keys.md" %}}

--- a/content/docs/agentgateway/latest/llm/failover.md
+++ b/content/docs/agentgateway/latest/llm/failover.md
@@ -3,5 +3,5 @@ title: Model failover
 weight: 35
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/failover.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/failover.md" %}}
 

--- a/content/docs/agentgateway/latest/llm/functions.md
+++ b/content/docs/agentgateway/latest/llm/functions.md
@@ -4,4 +4,4 @@ weight: 70
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/functions.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/functions.md" %}}

--- a/content/docs/agentgateway/latest/llm/guardrail-api/_index.md
+++ b/content/docs/agentgateway/latest/llm/guardrail-api/_index.md
@@ -4,7 +4,7 @@ weight: 70
 description:
 ---
 
-Use the Guardrail Webhook API to set up your own custom guardrail controls for {{< reuse "docs/snippets/agentgateway.md" >}}.
+Use the Guardrail Webhook API to set up your own custom guardrail controls for {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< cards >}}
   {{< card link="guardrails" title="Guardrails guide" >}}

--- a/content/docs/agentgateway/latest/llm/guardrail-api/guardrails.md
+++ b/content/docs/agentgateway/latest/llm/guardrail-api/guardrails.md
@@ -4,4 +4,4 @@ weight: 10
 description: Use the Guardrail Webhook API to set up your own custom guardrail controls.
 ---
  
-{{< reuse "docs/pages/agentgateway/guardrails.md" >}}
+{{% reuse "docs/pages/agentgateway/guardrails.md" %}}

--- a/content/docs/agentgateway/latest/llm/guardrail-api/openapi-spec.md
+++ b/content/docs/agentgateway/latest/llm/guardrail-api/openapi-spec.md
@@ -4,6 +4,6 @@ weight: 20
 description: OpenAPI reference docs for the Guardrail Webhook API for agentgateway.
 ---
 
-Review the OpenAPI reference docs for the Guardrail Webhook API for {{< reuse "docs/snippets/agentgateway.md" >}}.
+Review the OpenAPI reference docs for the Guardrail Webhook API for {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< openapi url="https://raw.githubusercontent.com/solo-io/gloo-gateway-use-cases/refs/heads/main/ai-guardrail-webhook-server/docs/gloo-ai-gateway-guardrail-webhook-openapi.yaml" >}}

--- a/content/docs/agentgateway/latest/llm/observability.md
+++ b/content/docs/agentgateway/latest/llm/observability.md
@@ -4,4 +4,4 @@ weight: 80
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/observability.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/observability.md" %}}

--- a/content/docs/agentgateway/latest/llm/prompt-enrichment.md
+++ b/content/docs/agentgateway/latest/llm/prompt-enrichment.md
@@ -3,4 +3,4 @@ title: Enrich prompts
 weight: 50
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/prompt-enrichment.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/prompt-enrichment.md" %}}

--- a/content/docs/agentgateway/latest/llm/prompt-guards.md
+++ b/content/docs/agentgateway/latest/llm/prompt-guards.md
@@ -3,4 +3,4 @@ title: Set up prompt guards
 weight: 40
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/prompt-guards.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/prompt-guards.md" %}}

--- a/content/docs/agentgateway/latest/llm/providers/anthropic.md
+++ b/content/docs/agentgateway/latest/llm/providers/anthropic.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/anthropic.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/anthropic.md" %}}
 

--- a/content/docs/agentgateway/latest/llm/providers/azureopenai.md
+++ b/content/docs/agentgateway/latest/llm/providers/azureopenai.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/azureopenai.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/azureopenai.md" %}}
 

--- a/content/docs/agentgateway/latest/llm/providers/bedrock.md
+++ b/content/docs/agentgateway/latest/llm/providers/bedrock.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/bedrock.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/bedrock.md" %}}

--- a/content/docs/agentgateway/latest/llm/providers/gemini.md
+++ b/content/docs/agentgateway/latest/llm/providers/gemini.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/gemini.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/gemini.md" %}}

--- a/content/docs/agentgateway/latest/llm/providers/openai-compatible.md
+++ b/content/docs/agentgateway/latest/llm/providers/openai-compatible.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/openai-compatible.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/openai-compatible.md" %}}
 

--- a/content/docs/agentgateway/latest/llm/providers/openai.md
+++ b/content/docs/agentgateway/latest/llm/providers/openai.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/openai.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/openai.md" %}}

--- a/content/docs/agentgateway/latest/llm/providers/vertex.md
+++ b/content/docs/agentgateway/latest/llm/providers/vertex.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/vertex.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/vertex.md" %}}
 

--- a/content/docs/agentgateway/latest/llm/tracing.md
+++ b/content/docs/agentgateway/latest/llm/tracing.md
@@ -4,4 +4,4 @@ weight: 100
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/tracing.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/tracing.md" %}}

--- a/content/docs/agentgateway/latest/mcp/_index.md
+++ b/content/docs/agentgateway/latest/mcp/_index.md
@@ -3,7 +3,7 @@ title: MCP connectivity
 weight: 40
 ---
 
-Route to Model Context Protocol (MCP) servers through  {{< reuse "docs/snippets/agentgateway.md" >}}.
+Route to Model Context Protocol (MCP) servers through  {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< cards >}}
   {{< card link="about" title="About" >}}

--- a/content/docs/agentgateway/latest/mcp/about.md
+++ b/content/docs/agentgateway/latest/mcp/about.md
@@ -4,4 +4,4 @@ weight: 5
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/about.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/about.md" %}}

--- a/content/docs/agentgateway/latest/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/latest/mcp/dynamic-mcp.md
@@ -3,4 +3,4 @@ title: Dynamic MCP
 weight: 20
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/dynamic.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/dynamic.md" %}}

--- a/content/docs/agentgateway/latest/mcp/https.md
+++ b/content/docs/agentgateway/latest/mcp/https.md
@@ -6,4 +6,4 @@ description:
 
 Configure your agentgateway proxy to connect to an MCP server by using the HTTPS protocol. 
 
-{{< reuse "docs/pages/agentgateway/mcp/https.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/https.md" %}}

--- a/content/docs/agentgateway/latest/mcp/multiplex-mcp.txt
+++ b/content/docs/agentgateway/latest/mcp/multiplex-mcp.txt
@@ -23,7 +23,7 @@ Note that only streamable HTTP is currently supported for label selectors. If yo
 
 ## Before you begin
 
-{{< reuse "docs/snippets/agentgateway-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway-prereq.md" %}}
 
 ## Step 1: Deploy MCP servers {#mcp-server-everythings}
 
@@ -167,7 +167,7 @@ Route to the federated MCP servers with agentgateway.
    metadata:
      name: agentgateway
    spec:
-     gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+     gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
      listeners:
      - protocol: HTTP
        port: 8080
@@ -321,7 +321,7 @@ Use the [MCP Inspector tool](https://modelcontextprotocol.io/legacy/tools/inspec
 
 ## Cleanup
 
-{{< reuse "docs/snippets/cleanup.md" >}}
+{{% reuse "docs/snippets/cleanup.md" %}}
 
 ```sh
 kubectl delete Deployment mcp-server-everything mcp-website-fetcher

--- a/content/docs/agentgateway/latest/mcp/static-mcp.md
+++ b/content/docs/agentgateway/latest/mcp/static-mcp.md
@@ -3,4 +3,4 @@ title: Static MCP
 weight: 10
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/static.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/static.md" %}}

--- a/content/docs/agentgateway/latest/observability/control-plane-metrics.md
+++ b/content/docs/agentgateway/latest/observability/control-plane-metrics.md
@@ -3,4 +3,4 @@ title: Control plane metrics
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/control-plane-metrics.md" >}}
+{{% reuse "docs/pages/observability/control-plane-metrics.md" %}}

--- a/content/docs/agentgateway/latest/observability/otel-stack.md
+++ b/content/docs/agentgateway/latest/observability/otel-stack.md
@@ -3,23 +3,23 @@ title: OTel stack
 weight: 10
 ---
 
-{{< reuse "docs/snippets/agentgateway/otel-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway/otel-prereq.md" %}}
 
-{{< reuse "docs/pages/observability/otel-stack.md" >}}
+{{% reuse "docs/pages/observability/otel-stack.md" %}}
 
 ## Step 4: Explore Grafana dashboards
 
-{{< reuse "docs/snippets/agentgateway/grafana-dashboards.md" >}}
+{{% reuse "docs/snippets/agentgateway/grafana-dashboards.md" %}}
 
 
 ## Cleanup
 
-{{< reuse "docs/snippets/cleanup.md" >}}
+{{% reuse "docs/snippets/cleanup.md" %}}
 
 1. Remove the configmap for the Envoy gateway proxy dashboard and delete the `envoy.json` file.
    ```sh
-   kubectl delete cm {{< reuse "docs/snippets/pod-name.md" >}}-dashboard -n telemetry
-   rm {{< reuse "docs/snippets/pod-name.md" >}}.json
+   kubectl delete cm {{% reuse "docs/snippets/pod-name.md" %}}-dashboard -n telemetry
+   rm {{% reuse "docs/snippets/pod-name.md" %}}.json
    ```
 
 2. Uninstall the Grafana Loki and Tempo components. 

--- a/content/docs/agentgateway/latest/operations/cli.txt
+++ b/content/docs/agentgateway/latest/operations/cli.txt
@@ -3,11 +3,11 @@ title: CLI
 weight: 10
 ---
 
-Manage the `{{< reuse "docs/snippets/cli-name.md" >}}` command line interface (CLI) tool.
+Manage the `{{% reuse "docs/snippets/cli-name.md" %}}` command line interface (CLI) tool.
 
 ## Quick installation {#latest}
 
-Install the latest version of `{{< reuse "docs/snippets/cli-name.md" >}}`. Make sure to add `{{< reuse "docs/snippets/cli-name.md" >}}` to your PATH (see [macOS](https://osxdaily.com/2014/08/14/add-new-path-to-path-command-line/) or [Linux](https://linuxize.com/post/how-to-add-directory-to-path-in-linux/) for specific instructions).
+Install the latest version of `{{% reuse "docs/snippets/cli-name.md" %}}`. Make sure to add `{{% reuse "docs/snippets/cli-name.md" %}}` to your PATH (see [macOS](https://osxdaily.com/2014/08/14/add-new-path-to-path-command-line/) or [Linux](https://linuxize.com/post/how-to-add-directory-to-path-in-linux/) for specific instructions).
 
 * Linux and macOS:
   ```shell
@@ -22,61 +22,61 @@ Install the latest version of `{{< reuse "docs/snippets/cli-name.md" >}}`. Make 
 
 ## Install a specific version of the CLI {#specific}
 
-You can download a specific version of `{{< reuse "docs/snippets/cli-name.md" >}}` directly from the GitHub releases page.
+You can download a specific version of `{{% reuse "docs/snippets/cli-name.md" %}}` directly from the GitHub releases page.
 
 1. In your browser, navigate to the [kgateway project releases](https://github.com/kgateway-dev/kgateway/releases).
-2. Choose the version of `{{< reuse "docs/snippets/cli-name.md" >}}` to install.
-3. Click the version of `{{< reuse "docs/snippets/cli-name.md" >}}` that you want to install.
-4. In the **Assets**, download the `{{< reuse "docs/snippets/cli-name.md" >}}` package that matches your operating system, and follow your operating system procedures for replacing your existing `{{< reuse "docs/snippets/cli-name.md" >}}` binary file with the upgraded version.
-5. After downloading, rename the executable to `{{< reuse "docs/snippets/cli-name.md" >}}` and add it to your system's `PATH`.
+2. Choose the version of `{{% reuse "docs/snippets/cli-name.md" %}}` to install.
+3. Click the version of `{{% reuse "docs/snippets/cli-name.md" %}}` that you want to install.
+4. In the **Assets**, download the `{{% reuse "docs/snippets/cli-name.md" %}}` package that matches your operating system, and follow your operating system procedures for replacing your existing `{{% reuse "docs/snippets/cli-name.md" %}}` binary file with the upgraded version.
+5. After downloading, rename the executable to `{{% reuse "docs/snippets/cli-name.md" %}}` and add it to your system's `PATH`.
 
 ## Upgrade the CLI
 
-When it's time to upgrade kgateway, make sure to update the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI version before upgrading.
+When it's time to upgrade kgateway, make sure to update the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI version before upgrading.
 
-You can use the `{{< reuse "docs/snippets/cli-name.md" >}} upgrade` command to upgrade or roll back the `{{< reuse "docs/snippets/cli-name.md" >}}` version. For example, you might change versions during an upgrade process, or when you have multiple versions of kgateway across clusters that you manage from the same workstation. For more options, run `{{< reuse "docs/snippets/cli-name.md" >}} upgrade --help`.
+You can use the `{{% reuse "docs/snippets/cli-name.md" %}} upgrade` command to upgrade or roll back the `{{% reuse "docs/snippets/cli-name.md" %}}` version. For example, you might change versions during an upgrade process, or when you have multiple versions of kgateway across clusters that you manage from the same workstation. For more options, run `{{% reuse "docs/snippets/cli-name.md" %}} upgrade --help`.
 
 {{< callout type="info" >}}
-Upgrading the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI does _not_ upgrade the kgateway version that you run in your clusters.
+Upgrading the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI does _not_ upgrade the kgateway version that you run in your clusters.
 {{< /callout >}}
 
-1. Set the version to upgrade `{{< reuse "docs/snippets/cli-name.md" >}}` to in an environment variable. Include the patch version.
+1. Set the version to upgrade `{{% reuse "docs/snippets/cli-name.md" %}}` to in an environment variable. Include the patch version.
    ```sh
    export CLI_VERSION=<version>
    ```
    
-2. Upgrade your version of `{{< reuse "docs/snippets/cli-name.md" >}}`.
+2. Upgrade your version of `{{% reuse "docs/snippets/cli-name.md" %}}`.
    ```bash
-   {{< reuse "docs/snippets/cli-name.md" >}} upgrade --release v${CLI_VERSION}
+   {{% reuse "docs/snippets/cli-name.md" %}} upgrade --release v${CLI_VERSION}
    ```
 
-3. Verify the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI is installed and running the appropriate version. In the output, the **Client** is your local version. The **Server** is the version that runs in your cluster, and is `undefined` if kgateway is not installed yet.
+3. Verify the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI is installed and running the appropriate version. In the output, the **Client** is your local version. The **Server** is the version that runs in your cluster, and is `undefined` if kgateway is not installed yet.
    ```bash
-   {{< reuse "docs/snippets/cli-name.md" >}} version -o table
+   {{% reuse "docs/snippets/cli-name.md" %}} version -o table
    ```
 
 ## Uninstall the CLI
 
-To uninstall `{{< reuse "docs/snippets/cli-name.md" >}}`, you can delete the executable file from your system, such as on macOS in the following example.
+To uninstall `{{% reuse "docs/snippets/cli-name.md" %}}`, you can delete the executable file from your system, such as on macOS in the following example.
 
 ```shell
-rm ~/.gloo/bin/{{< reuse "docs/snippets/cli-name.md" >}}
+rm ~/.gloo/bin/{{% reuse "docs/snippets/cli-name.md" %}}
 ```
 
 ## Skew policy
 
-Use the same version of the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI as the kgateway version that you installed in your cluster.
+Use the same version of the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI as the kgateway version that you installed in your cluster.
 
-* Slight skews within minor versions typically work, such as `{{< reuse "docs/snippets/cli-name.md" >}}` 1.18.1 and kgateway 1.18.0.
+* Slight skews within minor versions typically work, such as `{{% reuse "docs/snippets/cli-name.md" %}}` 1.18.1 and kgateway 1.18.0.
 * Compatibility across beta versions is not guaranteed, even within minor version skews.
-* To resolve bugs in `{{< reuse "docs/snippets/cli-name.md" >}}`, you might have to upgrade the CLI to a specific or latest version.
+* To resolve bugs in `{{% reuse "docs/snippets/cli-name.md" %}}`, you might have to upgrade the CLI to a specific or latest version.
 
 ## Reference documentation
 
-For more information about each `{{< reuse "docs/snippets/cli-name.md" >}}` command, see the [CLI documentation](/docs/reference/cli/) or run the help flag for a command.
+For more information about each `{{% reuse "docs/snippets/cli-name.md" %}}` command, see the [CLI documentation](/docs/reference/cli/) or run the help flag for a command.
 
 ```shell
-{{< reuse "docs/snippets/cli-name.md" >}} --help
+{{% reuse "docs/snippets/cli-name.md" %}} --help
 ```
 
 ## Other command line tools {#other-cli}
@@ -86,8 +86,8 @@ As you use kgateway, you might need the following common cluster management comm
 | CLI tool | Description |
 | -------- | ----------- |
 | Cloud provider CLI | The CLI to interact with your preferred cloud provider, such as `aws` or `gcloud`. You might also have local cluster testing tools such as `kind` or `k3d`. `gcloud`. |
-| [`istioctl`](https://istio.io/latest/docs/setup/getting-started/#download) | The Istio command line tool, if you plan to use the Istio integration in your kgateway environment. The guides in this documentation use Istio version {{< reuse "docs/versions/istio_patch.md" >}}. To check your installed version, run `istioctl version`. |
+| [`istioctl`](https://istio.io/latest/docs/setup/getting-started/#download) | The Istio command line tool, if you plan to use the Istio integration in your kgateway environment. The guides in this documentation use Istio version {{% reuse "docs/versions/istio_patch.md" %}}. To check your installed version, run `istioctl version`. |
 | [`helm`](https://helm.sh/docs/intro/install/)| The Kubernetes package manager, to customize multiple settings in a kgateway installation. |
 | [`jq`](https://stedolan.github.io/jq/download/) | Parse JSON output, such as from logs, to get values that you can use in subsequent commands, environment variables, or other contexts. |
 | [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) | The Kubernetes command line tool. Download the `kubectl` version that is within one minor version of the Kubernetes clusters you plan to use with kgateway. |
-| `openssl` | {{< reuse "docs/snippets/cert_openssl.md" >}} |
+| `openssl` | {{% reuse "docs/snippets/cert_openssl.md" %}} |

--- a/content/docs/agentgateway/latest/operations/debug.md
+++ b/content/docs/agentgateway/latest/operations/debug.md
@@ -3,4 +3,4 @@ title: Debug your setup
 weight: 15
 ---
 
-{{< reuse "docs/pages/operations/debug.md" >}}
+{{% reuse "docs/pages/operations/debug.md" %}}

--- a/content/docs/agentgateway/latest/operations/uninstall.md
+++ b/content/docs/agentgateway/latest/operations/uninstall.md
@@ -4,4 +4,4 @@ weight: 50
 description: Uninstall kgateway and related components.
 ---
 
-{{< reuse "docs/pages/operations/uninstall.md" >}}
+{{% reuse "docs/pages/operations/uninstall.md" %}}

--- a/content/docs/agentgateway/latest/operations/upgrade.md
+++ b/content/docs/agentgateway/latest/operations/upgrade.md
@@ -4,4 +4,4 @@ weight: 20
 description: Upgrade the control plane and any gateway proxies that run in your cluster. 
 ---
 
-{{< reuse "docs/pages/operations/upgrade.md" >}}
+{{% reuse "docs/pages/operations/upgrade.md" %}}

--- a/content/docs/agentgateway/latest/quickstart.md
+++ b/content/docs/agentgateway/latest/quickstart.md
@@ -5,4 +5,4 @@ weight: 1
 next: /docs/about
 ---
 
-{{< reuse "docs/pages/agentgateway/quickstart.md" >}}
+{{% reuse "docs/pages/agentgateway/quickstart.md" %}}

--- a/content/docs/agentgateway/latest/rbac.md
+++ b/content/docs/agentgateway/latest/rbac.md
@@ -4,4 +4,4 @@ weight: 65
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/rbac.md" >}}
+{{% reuse "docs/pages/agentgateway/rbac.md" %}}

--- a/content/docs/agentgateway/latest/reference/api.md
+++ b/content/docs/agentgateway/latest/reference/api.md
@@ -3,7 +3,7 @@ title: API reference
 weight: 10
 ---
 
-{{< reuse "/docs/snippets/api-ref-docs-intro.md" >}}
+{{% reuse "/docs/snippets/api-ref-docs-intro.md" %}}
 
 ## Packages
 - [gateway.kgateway.dev/v1alpha1](#gatewaykgatewaydevv1alpha1)

--- a/content/docs/agentgateway/latest/reference/helm/_index.md
+++ b/content/docs/agentgateway/latest/reference/helm/_index.md
@@ -10,12 +10,12 @@ You can download the Helm chart to review the Helm values that are supported.
 
 1. Download the Helm chart as an archive to your local machine. 
    ```sh
-   helm pull oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v{{< reuse "docs/versions/n-patch.md" >}}
+   helm pull oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v{{% reuse "docs/versions/n-patch.md" %}}
    ```
 
 2. Extract the files from the downloaded archive. 
    ```sh
-   tar -xvf kgateway-v{{< reuse "docs/versions/n-patch.md" >}}.tgz
+   tar -xvf kgateway-v{{% reuse "docs/versions/n-patch.md" %}}.tgz
    ```
 
 3. Open the Helm values file. 

--- a/content/docs/agentgateway/latest/reference/helm/kgateway-crds.md
+++ b/content/docs/agentgateway/latest/reference/helm/kgateway-crds.md
@@ -7,4 +7,4 @@ Review Helm values for the kgateway-crds Helm chart.
 
 This Helm chart controls whether specific sets of CRDs for agentgateway are installed. For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.1.x/kgateway-crds.md" >}}
+{{% reuse "docs/pages/reference/helm/2.1.x/kgateway-crds.md" %}}

--- a/content/docs/agentgateway/latest/reference/helm/kgateway.md
+++ b/content/docs/agentgateway/latest/reference/helm/kgateway.md
@@ -7,4 +7,4 @@ Review Helm values for the kgateway Helm chart.
 
 For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.1.x/kgateway.md" >}}
+{{% reuse "docs/pages/reference/helm/2.1.x/kgateway.md" %}}

--- a/content/docs/agentgateway/latest/routes.txt
+++ b/content/docs/agentgateway/latest/routes.txt
@@ -3,17 +3,17 @@ title: Routes
 weight: 70
 ---
 
-The {{< reuse "docs/snippets/agentgateway.md" >}} data plane supports the Gateway API routing resources, including HTTPRoute, GRPCRoute, TCPRoute, and TLSRoute.
+The {{% reuse "docs/snippets/agentgateway.md" %}} data plane supports the Gateway API routing resources, including HTTPRoute, GRPCRoute, TCPRoute, and TLSRoute.
 
 ## Before you begin
 
-{{< reuse "docs/snippets/agentgateway-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway-prereq.md" %}}
 
 ## HTTP
 
-Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy HTTP requests to your backend services.
+Use {{% reuse "docs/snippets/agentgateway.md" %}} to proxy HTTP requests to your backend services.
 
-1. Follow the [Sample HTTP app]({{< link-hextra path="/install/sample-app/" >}}) instructions to create a sample HTTP app, a Gateway with an HTTP listener that uses the `{{< reuse "/docs/snippets/agw-gatewayclass.md" >}}` GatewayClass, and an HTTPRoute.
+1. Follow the [Sample HTTP app]({{< link-hextra path="/install/sample-app/" >}}) instructions to create a sample HTTP app, a Gateway with an HTTP listener that uses the `{{% reuse "/docs/snippets/agw-gatewayclass.md" %}}` GatewayClass, and an HTTPRoute.
 
 2. Check out the following guides for more advanced routing use cases.
 
@@ -24,11 +24,11 @@ Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy HTTP requests to your
 
 ## Routes to external services {#static}
 
-Follow the [Static backend](../../traffic-management/destination-types/backends/static/) guide to create a static backend for an external HTTP service. Then, use an HTTPRoute to route traffic to that service through your agentgateway proxy. When you set up your Gateway, make sure to use the `{{< reuse "/docs/snippets/agw-gatewayclass.md" >}}` GatewayClass.
+Follow the [Static backend](../../traffic-management/destination-types/backends/static/) guide to create a static backend for an external HTTP service. Then, use an HTTPRoute to route traffic to that service through your agentgateway proxy. When you set up your Gateway, make sure to use the `{{% reuse "/docs/snippets/agw-gatewayclass.md" %}}` GatewayClass.
 
 ## gRPC
 
-Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy gRPC requests to your backend services.
+Use {{% reuse "docs/snippets/agentgateway.md" %}} to proxy gRPC requests to your backend services.
 
 1. Deploy a gRPC sample echo app and a sample gRPC curl client.
 
@@ -96,7 +96,7 @@ Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy gRPC requests to your
    EOF
    ```
 
-2. Create a Gateway that uses the `{{< reuse "/docs/snippets/agw-gatewayclass.md" >}}` GatewayClass and an HTTP listener that can be used for gRPC.
+2. Create a Gateway that uses the `{{% reuse "/docs/snippets/agw-gatewayclass.md" %}}` GatewayClass and an HTTP listener that can be used for gRPC.
 
    ```yaml
    kubectl apply -f- <<EOF
@@ -105,7 +105,7 @@ Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy gRPC requests to your
    metadata:
      name: agentgateway
    spec:
-     gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+     gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
      listeners:
        - protocol: HTTP
          port: 8080
@@ -187,7 +187,7 @@ Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy gRPC requests to your
    }
    ```
 
-6. Optional: {{< reuse "docs/snippets/cleanup.md" >}}
+6. Optional: {{% reuse "docs/snippets/cleanup.md" %}}
    
    ```sh
    kubectl delete Deployment grpc-echo
@@ -201,7 +201,7 @@ Use {{< reuse "docs/snippets/agentgateway.md" >}} to proxy gRPC requests to your
 
 Follow the [TCP listener guide](../../setup/listeners/tcp/) to create a TCP listener and a TCPRoute. 
 
-Make sure to create the Gateway with the `{{< reuse "/docs/snippets/agw-gatewayclass.md" >}}` GatewayClass.
+Make sure to create the Gateway with the `{{% reuse "/docs/snippets/agw-gatewayclass.md" %}}` GatewayClass.
 
 Example TCP listener configuration:
 
@@ -213,11 +213,11 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: tcp-gateway
-  namespace: {{< reuse "docs/snippets/namespace.md" >}}
+  namespace: {{% reuse "docs/snippets/namespace.md" %}}
   labels:
     app: tcp-echo
 spec:
-  gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+  gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
   listeners:
   - protocol: TCP
     port: 8000
@@ -228,11 +228,11 @@ spec:
 EOF
 ```
  
-{{< reuse "docs/snippets/review-table.md" >}}
+{{% reuse "docs/snippets/review-table.md" %}}
  
 |Setting|Description|
 |--|--|
-|`spec.gatewayClassName`| The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{< reuse "docs/snippets/agentgateway.md" >}}, set the `gatewayClassName` to `{{< reuse "docs/snippets/agw-gatewayclass.md" >}}`. |
+|`spec.gatewayClassName`| The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{% reuse "docs/snippets/agentgateway.md" %}}, set the `gatewayClassName` to `{{% reuse "docs/snippets/agw-gatewayclass.md" %}}`. |
 |`spec.listeners`|Configure the listeners for this Gateway. In this example, you configure a TCP Gateway that listens for incoming traffic on port 8000. The Gateway can serve TCPRoutes from any namespace. |
 
 {{% /tab %}}
@@ -246,11 +246,11 @@ EOF
    kind: Gateway
    metadata:
      name: tcp-gateway
-     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     namespace: {{% reuse "docs/snippets/namespace.md" %}}
      labels:
        app: tcp-echo
    spec:
-     gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+     gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
      allowedListeners:
        namespaces:
          from: All
@@ -264,13 +264,13 @@ EOF
    EOF
    ```
 
-   {{< reuse "docs/snippets/review-table.md" >}}
+   {{% reuse "docs/snippets/review-table.md" %}}
 
    |Setting|Description|
    |---|---|
-   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{< reuse "docs/snippets/agentgateway.md" >}}, set the `gatewayClassName` to `{{< reuse "docs/snippets/agw-gatewayclass.md" >}}`.|
+   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{% reuse "docs/snippets/agentgateway.md" %}}, set the `gatewayClassName` to `{{% reuse "docs/snippets/agw-gatewayclass.md" %}}`.|
    |`spec.allowedListeners`|Enable the attachment of ListenerSets to this Gateway. The example allows listeners from any namespace.|
-   |`spec.listeners`|{{< reuse "docs/snippets/generic-listener.md" >}} In this example, the generic listener is configured on port 80, which differs from port 8000 in the ListenerSet that you create later.|
+   |`spec.listeners`|{{% reuse "docs/snippets/generic-listener.md" %}} In this example, the generic listener is configured on port 80, which differs from port 8000 in the ListenerSet that you create later.|
 
 2. Create a ListenerSet that configures a TCP listener for the Gateway.
 
@@ -280,13 +280,13 @@ EOF
    kind: XListenerSet
    metadata:
      name: my-tcp-listenerset
-     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     namespace: {{% reuse "docs/snippets/namespace.md" %}}
      labels:
        app: tcp-echo
    spec:
      parentRef:
        name: tcp-gateway
-       namespace: {{< reuse "docs/snippets/namespace.md" >}}
+       namespace: {{% reuse "docs/snippets/namespace.md" %}}
        kind: Gateway
        group: gateway.networking.k8s.io
      listeners:
@@ -299,7 +299,7 @@ EOF
    EOF
    ```
 
-   {{< reuse "docs/snippets/review-table.md" >}}
+   {{% reuse "docs/snippets/review-table.md" %}}
 
    |Setting|Description|
    |--|--|
@@ -310,7 +310,7 @@ EOF
 
 ## TLS
 
-Follow the [TLS listener guide](../../setup/listeners/tls/) to create a TLS listener and a TLSRoute. Make sure to create the Gateway with the `{{< reuse "/docs/snippets/agw-gatewayclass.md" >}}` GatewayClass.
+Follow the [TLS listener guide](../../setup/listeners/tls/) to create a TLS listener and a TLSRoute. Make sure to create the Gateway with the `{{% reuse "/docs/snippets/agw-gatewayclass.md" %}}` GatewayClass.
 
 Example TLS listener configuration:
 
@@ -324,9 +324,9 @@ Example TLS listener configuration:
    kind: Gateway
    metadata:
      name: tls-passthrough
-     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     namespace: {{% reuse "docs/snippets/namespace.md" %}}
    spec:
-     gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+     gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
      listeners:
      - name: tls
        protocol: TLS
@@ -340,11 +340,11 @@ Example TLS listener configuration:
    EOF
    ```
 
-   {{< reuse "docs/snippets/review-table.md" >}}
+   {{% reuse "docs/snippets/review-table.md" %}}
 
    |Setting|Description|
    |---|---|
-   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{< reuse "docs/snippets/agentgateway.md" >}}, set the `gatewayClassName` to `{{< reuse "docs/snippets/agw-gatewayclass.md" >}}`.|
+   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{% reuse "docs/snippets/agentgateway.md" %}}, set the `gatewayClassName` to `{{% reuse "docs/snippets/agw-gatewayclass.md" %}}`.|
    |`spec.listeners`|Configure the listeners for this Gateway. In this example, you configure a TLS passthrough Gateway that listens for incoming traffic for the `nginx.example.com` domain on port 8443. The Gateway can serve TLS routes from any namespace.|
    |`spec.listeners.tls.mode`|The TLS mode for incoming requests. In this example, TLS requests are passed through to the backend service without being terminated at the Gateway.|
 
@@ -359,9 +359,9 @@ Example TLS listener configuration:
    kind: Gateway
    metadata:
      name: tls-passthrough
-     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     namespace: {{% reuse "docs/snippets/namespace.md" %}}
    spec:
-     gatewayClassName: {{< reuse "/docs/snippets/agw-gatewayclass.md" >}}
+     gatewayClassName: {{% reuse "/docs/snippets/agw-gatewayclass.md" %}}
      allowedListeners:
        namespaces:
          from: All
@@ -375,13 +375,13 @@ Example TLS listener configuration:
    EOF
    ```
 
-   {{< reuse "docs/snippets/review-table.md" >}}
+   {{% reuse "docs/snippets/review-table.md" %}}
 
    |Setting|Description|
    |---|---|
-   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{< reuse "docs/snippets/agentgateway.md" >}}, set the `gatewayClassName` to `{{< reuse "docs/snippets/agw-gatewayclass.md" >}}`. |
+   |`spec.gatewayClassName`|The name of the Kubernetes GatewayClass that you want to use to configure the Gateway. For {{% reuse "docs/snippets/agentgateway.md" %}}, set the `gatewayClassName` to `{{% reuse "docs/snippets/agw-gatewayclass.md" %}}`. |
    |`spec.allowedListeners`|Enable the attachment of ListenerSets to this Gateway. The example allows listeners from any namespace.|
-   |`spec.listeners`|{{< reuse "docs/snippets/generic-listener.md" >}} In this example, the generic listener is configured on port 80, which differs from port 443 in the ListenerSet that you create later.|
+   |`spec.listeners`|{{% reuse "docs/snippets/generic-listener.md" %}} In this example, the generic listener is configured on port 80, which differs from port 443 in the ListenerSet that you create later.|
 
 2. Create a ListenerSet that configures a TLS passthrough listener for the Gateway.
 
@@ -391,11 +391,11 @@ Example TLS listener configuration:
    kind: XListenerSet
    metadata:
      name: my-tls-listenerset
-     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     namespace: {{% reuse "docs/snippets/namespace.md" %}}
    spec:
      parentRef:
        name: tls-passthrough
-       namespace: {{< reuse "docs/snippets/namespace.md" >}}
+       namespace: {{% reuse "docs/snippets/namespace.md" %}}
        kind: Gateway
        group: gateway.networking.k8s.io
      listeners:
@@ -411,7 +411,7 @@ Example TLS listener configuration:
    EOF
    ```
 
-   {{< reuse "docs/snippets/review-table.md" >}}
+   {{% reuse "docs/snippets/review-table.md" %}}
 
    |Setting|Description|
    |--|--|

--- a/content/docs/agentgateway/latest/setup.md
+++ b/content/docs/agentgateway/latest/setup.md
@@ -4,19 +4,19 @@ weight: 15
 description:
 ---
 
-Set up an {{< reuse "docs/snippets/agentgateway.md" >}} proxy. 
+Set up an {{% reuse "docs/snippets/agentgateway.md" %}} proxy. 
 
 ## Before you begin
 
-{{< reuse "docs/snippets/agentgateway-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway-prereq.md" %}}
 
 ## Set up an agentgateway proxy
 
-{{< reuse "docs/snippets/agentgateway-setup.md" >}}
+{{% reuse "docs/snippets/agentgateway-setup.md" %}}
 
 ## Next
 
-Explore how you can use {{< reuse "docs/snippets/agentgateway.md" >}} by checking out guides for the most common use cases: 
+Explore how you can use {{% reuse "docs/snippets/agentgateway.md" %}} by checking out guides for the most common use cases: 
 * [LLM consumption]({{< link-hextra path="/agentgateway/llm" >}}) 
 * [Inference routing]({{< link-hextra path="/agentgateway/inference" >}}) 
 * [MCP connectivity]({{< link-hextra path="/agentgateway/mcp" >}}) 

--- a/content/docs/agentgateway/main/about/_index.md
+++ b/content/docs/agentgateway/main/about/_index.md
@@ -3,11 +3,12 @@ title: About
 weight: 10
 ---
 
-{{< reuse "docs/snippets/agentgateway/about.md" >}}
+{{% reuse "docs/snippets/agentgateway/about.md" %}}
 
-To learn more about {{< reuse "docs/snippets/agentgateway.md" >}}, review the following topics.
+To learn more about {{% reuse "docs/snippets/agentgateway.md" %}}, review the following topics.
 
 {{< cards >}}
   {{< card link="overview" title="Overview" >}}
   {{< card link="architecture" title="Architecture" >}}
+  {{< card link="gateway-api" title="Gateway API" >}}
 {{< /cards >}}

--- a/content/docs/agentgateway/main/about/architecture.md
+++ b/content/docs/agentgateway/main/about/architecture.md
@@ -4,4 +4,4 @@ weight: 15
 
 ---
 
-{{< reuse "docs/pages/about/architecture.md" >}}
+{{% reuse "docs/pages/about/architecture.md" %}}

--- a/content/docs/agentgateway/main/about/overview.md
+++ b/content/docs/agentgateway/main/about/overview.md
@@ -3,4 +3,4 @@ title: Overview
 weight: 10
 ---
 
-{{< reuse "docs/pages/agentgateway/about.md" >}}
+{{% reuse "docs/pages/agentgateway/about.md" %}}

--- a/content/docs/agentgateway/main/agent/a2a.md
+++ b/content/docs/agentgateway/main/agent/a2a.md
@@ -3,4 +3,4 @@ title: Connect to an agent
 weight: 40
 ---
 
-{{< reuse "docs/pages/agentgateway/agent/a2a.md" >}}
+{{% reuse "docs/pages/agentgateway/agent/a2a.md" %}}

--- a/content/docs/agentgateway/main/agent/about.md
+++ b/content/docs/agentgateway/main/agent/about.md
@@ -4,4 +4,4 @@ weight: 10
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/agent/about.md" >}}
+{{% reuse "docs/pages/agentgateway/agent/about.md" %}}

--- a/content/docs/agentgateway/main/configuration.md
+++ b/content/docs/agentgateway/main/configuration.md
@@ -4,4 +4,4 @@ weight: 65
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/configuration.md" >}}
+{{% reuse "docs/pages/agentgateway/configuration.md" %}}

--- a/content/docs/agentgateway/main/inference.md
+++ b/content/docs/agentgateway/main/inference.md
@@ -4,4 +4,4 @@ weight: 30
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/inference.md" >}}
+{{% reuse "docs/pages/agentgateway/inference.md" %}}

--- a/content/docs/agentgateway/main/install/_index.md
+++ b/content/docs/agentgateway/main/install/_index.md
@@ -4,7 +4,7 @@ weight: 14
 icon: settings
 ---
 
-Learn how to install the {{< reuse "/docs/snippets/kgateway.md" >}} {{< gloss "Control Plane" >}}control plane{{< /gloss >}} to use with {{< reuse "/docs/snippets/agentgateway.md" >}} {{< gloss "Data Plane" >}}data plane{{< /gloss >}} proxies.
+Learn how to install the {{% reuse "/docs/snippets/kgateway.md" %}} {{< gloss "Control Plane" >}}control plane{{< /gloss >}} to use with {{% reuse "/docs/snippets/agentgateway.md" %}} {{< gloss "Data Plane" >}}data plane{{< /gloss >}} proxies.
 
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}

--- a/content/docs/agentgateway/main/install/advanced.md
+++ b/content/docs/agentgateway/main/install/advanced.md
@@ -4,7 +4,7 @@ weight: 70
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/advanced.md" >}}
+{{% reuse "docs/pages/install/advanced.md" %}}
 
 
 

--- a/content/docs/agentgateway/main/install/argocd.md
+++ b/content/docs/agentgateway/main/install/argocd.md
@@ -4,7 +4,7 @@ weight: 10
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/argocd.md" >}}
+{{% reuse "docs/pages/install/argocd.md" %}}
 
 
 

--- a/content/docs/agentgateway/main/install/helm.md
+++ b/content/docs/agentgateway/main/install/helm.md
@@ -4,7 +4,7 @@ weight: 5
 description: Install kgateway and related components.
 ---
 
-{{< reuse "docs/pages/install/helm.md" >}}
+{{% reuse "docs/pages/install/helm.md" %}}
 
 
 

--- a/content/docs/agentgateway/main/install/tls.md
+++ b/content/docs/agentgateway/main/install/tls.md
@@ -3,7 +3,7 @@ title: TLS encryption
 weight: 100
 ---
 
-{{< reuse "docs/pages/install/tls.md" >}}
+{{% reuse "docs/pages/install/tls.md" %}}
 
 
 

--- a/content/docs/agentgateway/main/llm/about.md
+++ b/content/docs/agentgateway/main/llm/about.md
@@ -4,5 +4,5 @@ weight: 10
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/about.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/about.md" %}}
 

--- a/content/docs/agentgateway/main/llm/api-keys.md
+++ b/content/docs/agentgateway/main/llm/api-keys.md
@@ -4,4 +4,4 @@ weight: 30
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/api-keys.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/api-keys.md" %}}

--- a/content/docs/agentgateway/main/llm/failover.md
+++ b/content/docs/agentgateway/main/llm/failover.md
@@ -3,4 +3,4 @@ title: Model failover
 weight: 35
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/failover.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/failover.md" %}}

--- a/content/docs/agentgateway/main/llm/functions.md
+++ b/content/docs/agentgateway/main/llm/functions.md
@@ -4,4 +4,4 @@ weight: 70
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/functions.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/functions.md" %}}

--- a/content/docs/agentgateway/main/llm/guardrail-api/_index.md
+++ b/content/docs/agentgateway/main/llm/guardrail-api/_index.md
@@ -4,7 +4,7 @@ weight: 70
 description:
 ---
 
-Use the Guardrail Webhook API to set up your own custom guardrail controls for {{< reuse "docs/snippets/agentgateway.md" >}}.
+Use the Guardrail Webhook API to set up your own custom guardrail controls for {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< cards >}}
   {{< card link="guardrails" title="Guardrails guide" >}}

--- a/content/docs/agentgateway/main/llm/guardrail-api/guardrails.md
+++ b/content/docs/agentgateway/main/llm/guardrail-api/guardrails.md
@@ -4,4 +4,4 @@ weight: 10
 description: Use the Guardrail Webhook API to set up your own custom guardrail controls.
 ---
  
-{{< reuse "docs/pages/agentgateway/guardrails.md" >}}
+{{% reuse "docs/pages/agentgateway/guardrails.md" %}}

--- a/content/docs/agentgateway/main/llm/guardrail-api/openapi-spec.md
+++ b/content/docs/agentgateway/main/llm/guardrail-api/openapi-spec.md
@@ -4,6 +4,6 @@ weight: 20
 description: OpenAPI reference docs for the Guardrail Webhook API for agentgateway.
 ---
 
-Review the OpenAPI reference docs for the Guardrail Webhook API for {{< reuse "docs/snippets/agentgateway.md" >}}.
+Review the OpenAPI reference docs for the Guardrail Webhook API for {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< openapi url="https://raw.githubusercontent.com/solo-io/gloo-gateway-use-cases/refs/heads/main/ai-guardrail-webhook-server/docs/gloo-ai-gateway-guardrail-webhook-openapi.yaml" >}}

--- a/content/docs/agentgateway/main/llm/observability.md
+++ b/content/docs/agentgateway/main/llm/observability.md
@@ -4,4 +4,4 @@ weight: 80
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/observability.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/observability.md" %}}

--- a/content/docs/agentgateway/main/llm/prompt-enrichment.md
+++ b/content/docs/agentgateway/main/llm/prompt-enrichment.md
@@ -3,4 +3,4 @@ title: Enrich prompts
 weight: 50
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/prompt-enrichment.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/prompt-enrichment.md" %}}

--- a/content/docs/agentgateway/main/llm/prompt-guards.md
+++ b/content/docs/agentgateway/main/llm/prompt-guards.md
@@ -3,4 +3,4 @@ title: Set up prompt guards
 weight: 40
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/prompt-guards.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/prompt-guards.md" %}}

--- a/content/docs/agentgateway/main/llm/providers/anthropic.md
+++ b/content/docs/agentgateway/main/llm/providers/anthropic.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/anthropic.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/anthropic.md" %}}
 

--- a/content/docs/agentgateway/main/llm/providers/azureopenai.md
+++ b/content/docs/agentgateway/main/llm/providers/azureopenai.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/azureopenai.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/azureopenai.md" %}}
 

--- a/content/docs/agentgateway/main/llm/providers/bedrock.md
+++ b/content/docs/agentgateway/main/llm/providers/bedrock.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/bedrock.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/bedrock.md" %}}

--- a/content/docs/agentgateway/main/llm/providers/gemini.md
+++ b/content/docs/agentgateway/main/llm/providers/gemini.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/gemini.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/gemini.md" %}}

--- a/content/docs/agentgateway/main/llm/providers/multiple-endpoints.md
+++ b/content/docs/agentgateway/main/llm/providers/multiple-endpoints.md
@@ -4,5 +4,5 @@ weight: 40
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/multiple-endpoints.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/multiple-endpoints.md" %}}
 

--- a/content/docs/agentgateway/main/llm/providers/openai-compatible.md
+++ b/content/docs/agentgateway/main/llm/providers/openai-compatible.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/openai-compatible2.2+.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/openai-compatible2.2+.md" %}}

--- a/content/docs/agentgateway/main/llm/providers/openai.md
+++ b/content/docs/agentgateway/main/llm/providers/openai.md
@@ -4,4 +4,4 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/openai.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/openai.md" %}}

--- a/content/docs/agentgateway/main/llm/providers/vertex.md
+++ b/content/docs/agentgateway/main/llm/providers/vertex.md
@@ -4,5 +4,5 @@ weight: 20
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/providers/vertex.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/providers/vertex.md" %}}
 

--- a/content/docs/agentgateway/main/llm/tracing.md
+++ b/content/docs/agentgateway/main/llm/tracing.md
@@ -4,4 +4,4 @@ weight: 100
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/llm/tracing.md" >}}
+{{% reuse "docs/pages/agentgateway/llm/tracing.md" %}}

--- a/content/docs/agentgateway/main/mcp/_index.md
+++ b/content/docs/agentgateway/main/mcp/_index.md
@@ -3,7 +3,7 @@ title: MCP connectivity
 weight: 40
 ---
 
-Route to Model Context Protocol (MCP) servers through  {{< reuse "docs/snippets/agentgateway.md" >}}.
+Route to Model Context Protocol (MCP) servers through  {{% reuse "docs/snippets/agentgateway.md" %}}.
 
 {{< cards >}}
   {{< card link="about" title="About" >}}

--- a/content/docs/agentgateway/main/mcp/about.md
+++ b/content/docs/agentgateway/main/mcp/about.md
@@ -4,4 +4,4 @@ weight: 5
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/about.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/about.md" %}}

--- a/content/docs/agentgateway/main/mcp/dynamic-mcp.md
+++ b/content/docs/agentgateway/main/mcp/dynamic-mcp.md
@@ -3,4 +3,4 @@ title: Dynamic MCP
 weight: 20
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/dynamic.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/dynamic.md" %}}

--- a/content/docs/agentgateway/main/mcp/mcp-access.md
+++ b/content/docs/agentgateway/main/mcp/mcp-access.md
@@ -3,4 +3,4 @@ title: Secure access to MCP servers
 weight: 50
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/mcp-access.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/mcp-access.md" %}}

--- a/content/docs/agentgateway/main/mcp/multiplex.md
+++ b/content/docs/agentgateway/main/mcp/multiplex.md
@@ -3,4 +3,4 @@ title: Multiplex MCP
 weight: 30
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/multiplex.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/multiplex.md" %}}

--- a/content/docs/agentgateway/main/mcp/static-mcp.md
+++ b/content/docs/agentgateway/main/mcp/static-mcp.md
@@ -3,4 +3,4 @@ title: Static MCP
 weight: 10
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/static.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/static.md" %}}

--- a/content/docs/agentgateway/main/mcp/tool-access.md
+++ b/content/docs/agentgateway/main/mcp/tool-access.md
@@ -3,4 +3,4 @@ title: Control access to tools
 weight: 60
 ---
 
-{{< reuse "docs/pages/agentgateway/mcp/tool-access.md" >}}
+{{% reuse "docs/pages/agentgateway/mcp/tool-access.md" %}}

--- a/content/docs/agentgateway/main/observability/control-plane-metrics.md
+++ b/content/docs/agentgateway/main/observability/control-plane-metrics.md
@@ -3,4 +3,4 @@ title: Control plane metrics
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/control-plane-metrics.md" >}}
+{{% reuse "docs/pages/observability/control-plane-metrics.md" %}}

--- a/content/docs/agentgateway/main/observability/nacks.md
+++ b/content/docs/agentgateway/main/observability/nacks.md
@@ -3,4 +3,4 @@ title: Monitoring agentgateway proxies for NACKs
 weight: 80
 ---
 
-{{< reuse "docs/pages/agentgateway/monitoring-agentgateway-nacks.md" >}}
+{{% reuse "docs/pages/agentgateway/monitoring-agentgateway-nacks.md" %}}

--- a/content/docs/agentgateway/main/observability/otel-stack.md
+++ b/content/docs/agentgateway/main/observability/otel-stack.md
@@ -3,23 +3,23 @@ title: OTel stack
 weight: 10
 ---
 
-{{< reuse "docs/snippets/agentgateway/otel-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway/otel-prereq.md" %}}
 
-{{< reuse "docs/pages/observability/otel-stack.md" >}}
+{{% reuse "docs/pages/observability/otel-stack.md" %}}
 
 ## Step 4: Explore Grafana dashboards
 
-{{< reuse "docs/snippets/agentgateway/grafana-dashboards.md" >}}
+{{% reuse "docs/snippets/agentgateway/grafana-dashboards.md" %}}
 
 
 ## Cleanup
 
-{{< reuse "docs/snippets/cleanup.md" >}}
+{{% reuse "docs/snippets/cleanup.md" %}}
 
 1. Remove the configmap for the Envoy gateway proxy dashboard and delete the `envoy.json` file.
    ```sh
-   kubectl delete cm {{< reuse "docs/snippets/pod-name.md" >}}-dashboard -n telemetry
-   rm {{< reuse "docs/snippets/pod-name.md" >}}.json
+   kubectl delete cm {{% reuse "docs/snippets/pod-name.md" %}}-dashboard -n telemetry
+   rm {{% reuse "docs/snippets/pod-name.md" %}}.json
    ```
 
 2. Uninstall the Grafana Loki and Tempo components. 

--- a/content/docs/agentgateway/main/operations/cli.txt
+++ b/content/docs/agentgateway/main/operations/cli.txt
@@ -3,11 +3,11 @@ title: CLI
 weight: 10
 ---
 
-Manage the `{{< reuse "docs/snippets/cli-name.md" >}}` command line interface (CLI) tool.
+Manage the `{{% reuse "docs/snippets/cli-name.md" %}}` command line interface (CLI) tool.
 
 ## Quick installation {#latest}
 
-Install the latest version of `{{< reuse "docs/snippets/cli-name.md" >}}`. Make sure to add `{{< reuse "docs/snippets/cli-name.md" >}}` to your PATH (see [macOS](https://osxdaily.com/2014/08/14/add-new-path-to-path-command-line/) or [Linux](https://linuxize.com/post/how-to-add-directory-to-path-in-linux/) for specific instructions).
+Install the latest version of `{{% reuse "docs/snippets/cli-name.md" %}}`. Make sure to add `{{% reuse "docs/snippets/cli-name.md" %}}` to your PATH (see [macOS](https://osxdaily.com/2014/08/14/add-new-path-to-path-command-line/) or [Linux](https://linuxize.com/post/how-to-add-directory-to-path-in-linux/) for specific instructions).
 
 * Linux and macOS:
   ```shell
@@ -22,61 +22,61 @@ Install the latest version of `{{< reuse "docs/snippets/cli-name.md" >}}`. Make 
 
 ## Install a specific version of the CLI {#specific}
 
-You can download a specific version of `{{< reuse "docs/snippets/cli-name.md" >}}` directly from the GitHub releases page.
+You can download a specific version of `{{% reuse "docs/snippets/cli-name.md" %}}` directly from the GitHub releases page.
 
 1. In your browser, navigate to the [kgateway project releases](https://github.com/kgateway-dev/kgateway/releases).
-2. Choose the version of `{{< reuse "docs/snippets/cli-name.md" >}}` to install.
-3. Click the version of `{{< reuse "docs/snippets/cli-name.md" >}}` that you want to install.
-4. In the **Assets**, download the `{{< reuse "docs/snippets/cli-name.md" >}}` package that matches your operating system, and follow your operating system procedures for replacing your existing `{{< reuse "docs/snippets/cli-name.md" >}}` binary file with the upgraded version.
-5. After downloading, rename the executable to `{{< reuse "docs/snippets/cli-name.md" >}}` and add it to your system's `PATH`.
+2. Choose the version of `{{% reuse "docs/snippets/cli-name.md" %}}` to install.
+3. Click the version of `{{% reuse "docs/snippets/cli-name.md" %}}` that you want to install.
+4. In the **Assets**, download the `{{% reuse "docs/snippets/cli-name.md" %}}` package that matches your operating system, and follow your operating system procedures for replacing your existing `{{% reuse "docs/snippets/cli-name.md" %}}` binary file with the upgraded version.
+5. After downloading, rename the executable to `{{% reuse "docs/snippets/cli-name.md" %}}` and add it to your system's `PATH`.
 
 ## Upgrade the CLI
 
-When it's time to upgrade kgateway, make sure to update the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI version before upgrading.
+When it's time to upgrade kgateway, make sure to update the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI version before upgrading.
 
-You can use the `{{< reuse "docs/snippets/cli-name.md" >}} upgrade` command to upgrade or roll back the `{{< reuse "docs/snippets/cli-name.md" >}}` version. For example, you might change versions during an upgrade process, or when you have multiple versions of kgateway across clusters that you manage from the same workstation. For more options, run `{{< reuse "docs/snippets/cli-name.md" >}} upgrade --help`.
+You can use the `{{% reuse "docs/snippets/cli-name.md" %}} upgrade` command to upgrade or roll back the `{{% reuse "docs/snippets/cli-name.md" %}}` version. For example, you might change versions during an upgrade process, or when you have multiple versions of kgateway across clusters that you manage from the same workstation. For more options, run `{{% reuse "docs/snippets/cli-name.md" %}} upgrade --help`.
 
 {{< callout type="info" >}}
-Upgrading the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI does _not_ upgrade the kgateway version that you run in your clusters.
+Upgrading the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI does _not_ upgrade the kgateway version that you run in your clusters.
 {{< /callout >}}
 
-1. Set the version to upgrade `{{< reuse "docs/snippets/cli-name.md" >}}` to in an environment variable. Include the patch version.
+1. Set the version to upgrade `{{% reuse "docs/snippets/cli-name.md" %}}` to in an environment variable. Include the patch version.
    ```sh
    export CLI_VERSION=<version>
    ```
    
-2. Upgrade your version of `{{< reuse "docs/snippets/cli-name.md" >}}`.
+2. Upgrade your version of `{{% reuse "docs/snippets/cli-name.md" %}}`.
    ```bash
-   {{< reuse "docs/snippets/cli-name.md" >}} upgrade --release v${CLI_VERSION}
+   {{% reuse "docs/snippets/cli-name.md" %}} upgrade --release v${CLI_VERSION}
    ```
 
-3. Verify the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI is installed and running the appropriate version. In the output, the **Client** is your local version. The **Server** is the version that runs in your cluster, and is `undefined` if kgateway is not installed yet.
+3. Verify the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI is installed and running the appropriate version. In the output, the **Client** is your local version. The **Server** is the version that runs in your cluster, and is `undefined` if kgateway is not installed yet.
    ```bash
-   {{< reuse "docs/snippets/cli-name.md" >}} version -o table
+   {{% reuse "docs/snippets/cli-name.md" %}} version -o table
    ```
 
 ## Uninstall the CLI
 
-To uninstall `{{< reuse "docs/snippets/cli-name.md" >}}`, you can delete the executable file from your system, such as on macOS in the following example.
+To uninstall `{{% reuse "docs/snippets/cli-name.md" %}}`, you can delete the executable file from your system, such as on macOS in the following example.
 
 ```shell
-rm ~/.gloo/bin/{{< reuse "docs/snippets/cli-name.md" >}}
+rm ~/.gloo/bin/{{% reuse "docs/snippets/cli-name.md" %}}
 ```
 
 ## Skew policy
 
-Use the same version of the `{{< reuse "docs/snippets/cli-name.md" >}}` CLI as the kgateway version that you installed in your cluster.
+Use the same version of the `{{% reuse "docs/snippets/cli-name.md" %}}` CLI as the kgateway version that you installed in your cluster.
 
-* Slight skews within minor versions typically work, such as `{{< reuse "docs/snippets/cli-name.md" >}}` 1.18.1 and kgateway 1.18.0.
+* Slight skews within minor versions typically work, such as `{{% reuse "docs/snippets/cli-name.md" %}}` 1.18.1 and kgateway 1.18.0.
 * Compatibility across beta versions is not guaranteed, even within minor version skews.
-* To resolve bugs in `{{< reuse "docs/snippets/cli-name.md" >}}`, you might have to upgrade the CLI to a specific or latest version.
+* To resolve bugs in `{{% reuse "docs/snippets/cli-name.md" %}}`, you might have to upgrade the CLI to a specific or latest version.
 
 ## Reference documentation
 
-For more information about each `{{< reuse "docs/snippets/cli-name.md" >}}` command, see the [CLI documentation](/docs/reference/cli/) or run the help flag for a command.
+For more information about each `{{% reuse "docs/snippets/cli-name.md" %}}` command, see the [CLI documentation](/docs/reference/cli/) or run the help flag for a command.
 
 ```shell
-{{< reuse "docs/snippets/cli-name.md" >}} --help
+{{% reuse "docs/snippets/cli-name.md" %}} --help
 ```
 
 ## Other command line tools {#other-cli}
@@ -86,8 +86,8 @@ As you use kgateway, you might need the following common cluster management comm
 | CLI tool | Description |
 | -------- | ----------- |
 | Cloud provider CLI | The CLI to interact with your preferred cloud provider, such as `aws` or `gcloud`. You might also have local cluster testing tools such as `kind` or `k3d`. `gcloud`. |
-| [`istioctl`](https://istio.io/latest/docs/setup/getting-started/#download) | The Istio command line tool, if you plan to use the Istio integration in your kgateway environment. The guides in this documentation use Istio version {{< reuse "docs/versions/istio_patch.md" >}}. To check your installed version, run `istioctl version`. |
+| [`istioctl`](https://istio.io/latest/docs/setup/getting-started/#download) | The Istio command line tool, if you plan to use the Istio integration in your kgateway environment. The guides in this documentation use Istio version {{% reuse "docs/versions/istio_patch.md" %}}. To check your installed version, run `istioctl version`. |
 | [`helm`](https://helm.sh/docs/intro/install/)| The Kubernetes package manager, to customize multiple settings in a kgateway installation. |
 | [`jq`](https://stedolan.github.io/jq/download/) | Parse JSON output, such as from logs, to get values that you can use in subsequent commands, environment variables, or other contexts. |
 | [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) | The Kubernetes command line tool. Download the `kubectl` version that is within one minor version of the Kubernetes clusters you plan to use with kgateway. |
-| `openssl` | {{< reuse "docs/snippets/cert_openssl.md" >}} |
+| `openssl` | {{% reuse "docs/snippets/cert_openssl.md" %}} |

--- a/content/docs/agentgateway/main/operations/debug.md
+++ b/content/docs/agentgateway/main/operations/debug.md
@@ -3,4 +3,4 @@ title: Debug your setup
 weight: 15
 ---
 
-{{< reuse "docs/pages/operations/debug.md" >}}
+{{% reuse "docs/pages/operations/debug.md" %}}

--- a/content/docs/agentgateway/main/operations/uninstall.md
+++ b/content/docs/agentgateway/main/operations/uninstall.md
@@ -4,4 +4,4 @@ weight: 50
 description: Uninstall kgateway and related components.
 ---
 
-{{< reuse "docs/pages/operations/uninstall.md" >}}
+{{% reuse "docs/pages/operations/uninstall.md" %}}

--- a/content/docs/agentgateway/main/operations/upgrade.md
+++ b/content/docs/agentgateway/main/operations/upgrade.md
@@ -4,4 +4,4 @@ weight: 20
 description: Upgrade the control plane and any gateway proxies that run in your cluster. 
 ---
 
-{{< reuse "docs/pages/operations/upgrade.md" >}}
+{{% reuse "docs/pages/operations/upgrade.md" %}}

--- a/content/docs/agentgateway/main/quickstart.md
+++ b/content/docs/agentgateway/main/quickstart.md
@@ -5,4 +5,4 @@ weight: 1
 next: /docs/about
 ---
 
-{{< reuse "docs/pages/agentgateway/quickstart.md" >}}
+{{% reuse "docs/pages/agentgateway/quickstart.md" %}}

--- a/content/docs/agentgateway/main/rbac.md
+++ b/content/docs/agentgateway/main/rbac.md
@@ -4,4 +4,4 @@ weight: 65
 description:
 ---
 
-{{< reuse "docs/pages/agentgateway/rbac.md" >}}
+{{% reuse "docs/pages/agentgateway/rbac.md" %}}

--- a/content/docs/agentgateway/main/reference/api.md
+++ b/content/docs/agentgateway/main/reference/api.md
@@ -3,7 +3,7 @@ title: API reference
 weight: 10
 ---
 
-{{< reuse "/docs/snippets/api-ref-docs-intro.md" >}}
+{{% reuse "/docs/snippets/api-ref-docs-intro.md" %}}
 
 ## Packages
 - [agentgateway.dev/v1alpha1](#agentgatewaydevv1alpha1)

--- a/content/docs/agentgateway/main/reference/helm/_index.md
+++ b/content/docs/agentgateway/main/reference/helm/_index.md
@@ -10,12 +10,12 @@ You can download the Helm chart to review the Helm values that are supported.
 
 1. Download the Helm chart as an archive to your local machine. 
    ```sh
-   helm pull oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v{{< reuse "docs/versions/n-patch.md" >}}
+   helm pull oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v{{% reuse "docs/versions/n-patch.md" %}}
    ```
 
 2. Extract the files from the downloaded archive. 
    ```sh
-   tar -xvf kgateway-v{{< reuse "docs/versions/n-patch.md" >}}.tgz
+   tar -xvf kgateway-v{{% reuse "docs/versions/n-patch.md" %}}.tgz
    ```
 
 3. Open the Helm values file. 

--- a/content/docs/agentgateway/main/reference/helm/agentgateway-crds..md
+++ b/content/docs/agentgateway/main/reference/helm/agentgateway-crds..md
@@ -7,4 +7,4 @@ Review Helm values for the agentgateway-crds Helm chart.
 
 This Helm chart controls whether specific sets of CRDs for agentgateway are installed. For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.2.x/agentgateway-crds.md" >}}
+{{% reuse "docs/pages/reference/helm/2.2.x/agentgateway-crds.md" %}}

--- a/content/docs/agentgateway/main/reference/helm/agentgateway.md
+++ b/content/docs/agentgateway/main/reference/helm/agentgateway.md
@@ -7,4 +7,4 @@ Review Helm values for the agentgateway Helm chart.
 
 For more information about using this Helm chart, see the [Helm installation guide]({{< link-hextra path="/install/helm" >}}).
 
-{{< reuse "docs/pages/reference/helm/2.2.x/agentgateway.md" >}}
+{{% reuse "docs/pages/reference/helm/2.2.x/agentgateway.md" %}}

--- a/content/docs/agentgateway/main/setup.md
+++ b/content/docs/agentgateway/main/setup.md
@@ -8,15 +8,15 @@ Set up an agentgateway proxy.
 
 ## Before you begin
 
-{{< reuse "docs/snippets/agentgateway-prereq.md" >}}
+{{% reuse "docs/snippets/agentgateway-prereq.md" %}}
 
 ## Set up an agentgateway proxy
 
-{{< reuse "docs/snippets/agentgateway-setup.md" >}}
+{{% reuse "docs/snippets/agentgateway-setup.md" %}}
 
 ## Next
 
-Explore how you can use {{< reuse "docs/snippets/agentgateway.md" >}} by checking out guides for the most common use cases: 
+Explore how you can use {{% reuse "docs/snippets/agentgateway.md" %}} by checking out guides for the most common use cases: 
 * [LLM consumption]({{< link-hextra path="/agentgateway/llm" >}}) 
 * [Inference routing]({{< link-hextra path="/agentgateway/inference" >}}) 
 * [MCP connectivity]({{< link-hextra path="/agentgateway/mcp" >}}) 


### PR DESCRIPTION
When using `< reuse >` the content is mangled in some way. Not 100% sure how but it doesn't get `<p>` tags, which makes the CSS different and we end up with very compressed text (small line spacing).

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
