### PR TITLE
docs: add early request header modification guide

### DIFF
--- a/content/docs/latest/traffic-management/header-control/_index.md
+++ b/content/docs/latest/traffic-management/header-control/_index.md
@@ -7,6 +7,12 @@ Modify the headers of HTTP requests and responses.
 
 ## Configuration options {#options}
 
+You can modify headers in kgateway using **three options**:
+
+1. **HTTPRoute** — Modify request/response headers after route selection.
+2. **TrafficPolicy** — Apply policies to headers after route selection.
+3. **HTTPListenerPolicy** — New in v2.2, allows early request header modification before route selection. This ensures headers cannot influence routing or downstream policy evaluation. See the [Early request header modification guide](early-request-header-modifier.md) for full details.
+
 {{< reuse "docs/snippets/header-control-options.md" >}}
 
 ## Guides

--- a/content/docs/latest/traffic-management/header-control/early-request-header-modifier.md
+++ b/content/docs/latest/traffic-management/header-control/early-request-header-modifier.md
@@ -4,24 +4,21 @@ description: Modify and sanitize HTTP request headers before route selection occ
 weight: 30
 ---
 
-Early request header modification allows you to **add, set, or remove HTTP request headers at the listener level, before route selection and other request processing occurs**.
+Early request header modification allows you to add, set, or remove HTTP request headers at the listener level, before route selection and other request processing occurs.
 
-This capability is especially useful for **security and sanitization use cases**, where you want to ensure that sensitive headers cannot be faked by downstream clients and are only set by trusted components such as external authentication services.
+This capability is especially useful for security and sanitization use cases, where you want to ensure that sensitive headers cannot be faked by downstream clients and are only set by trusted components such as external authentication services.
 
-## When to use early request header modification
+## Before you begin
 
-Use `earlyRequestHeaderModifier` when you need to:
+Before configuring early request header modification, ensure that:
 
-- Sanitize incoming request headers **before routing decisions are made**
-- Remove headers that should only be added by trusted systems
-- Enforce security boundaries when handling untrusted downstream traffic
-- Apply header mutations earlier than standard request header modifiers
+- You have a Kubernetes cluster running.
+- kgateway is installed and configured.
+- A Gateway resource is already deployed in your cluster.
 
-Unlike standard request header modification, early header modification runs **before route matching**, ensuring headers do not influence routing or policy decisions.
+## Configuration
 
-## Configuration overview
-
-Early request header modification is configured on an `HTTPListenerPolicy` using the `earlyRequestHeaderModifier` field.
+Early request header modification is configured on an `HTTPListenerPolicy` using the `earlyRequestHeaderModifier` field. This policy is attached directly to a Gateway and applies header mutations before route selection.
 
 The configuration uses the standard Gateway API `HTTPHeaderFilter` format and supports the following operations:
 
@@ -29,7 +26,7 @@ The configuration uses the standard Gateway API `HTTPHeaderFilter` format and su
 - `set`
 - `remove`
 
-## Example: Sanitizing incoming headers
+### Example: Sanitizing incoming headers
 
 The following example removes a header that should only be added by an external authentication service, ensuring it cannot be supplied by the client.
 
@@ -39,27 +36,41 @@ kind: HTTPListenerPolicy
 metadata:
   name: sanitize-incoming-headers
 spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: http
   earlyRequestHeaderModifier:
     remove:
       - x-user-id
 ```
-In this example:
+{{< reuse "docs/snippets/review-table.md" >}} For more information about the available fields, see the [API reference]({{< link-hextra path="/reference/api/#httplistenerpolicyspec" >}}).
 
-- The `x-user-id` header is removed as soon as the request is received
+| Setting                    | Description                                              |
+|----------------------------|----------------------------------------------------------|
+| targetRefs                 | References the Gateway resources this policy applies to  |
+| earlyRequestHeaderModifier | Header mutations applied before route selection         |
 
-- Route selection and downstream filters will not see the header
+Apply the policy:
+```bash
+kubectl apply -f sanitize-incoming-headers.yaml
+```
+After this policy is applied:
 
-- Any value supplied by a client is effectively ignored
+- The `x-user-id` header is removed as soon as the request is received.
 
+- Route selection and downstream filters will not see the header.
+
+- Any value supplied by a client is effectively ignored.
+
+To remove the policy:
+```bash
+kubectl delete httplistenerpolicy sanitize-incoming-headers
+```
 ## Relationship to standard request header modification
+Early request header modification differs from standard request header modification in when it is applied during request processing.
 
-| Feature                          | Execution timing        |
-|----------------------------------|------------------------|
+| Feature                           | Execution timing        |
+|----------------------------------|-------------------------|
 | Early request header modification | Before route selection |
 | Request header modification       | After route selection  |
-
-If your use case depends on preventing headers from affecting routing or policy evaluation, early request header modification is the correct choice.
-
-## API reference
-
-The `earlyRequestHeaderModifier` field is part of the [HTTPListenerPolicy API](../../../reference/api/#httplistenerpolicyspec). Refer to the API documentation for full field definitions and schema details.


### PR DESCRIPTION
### Summary
Adds documentation for early request header modification and links it into the Header Control guides section.

### Details
- Documents the `earlyRequestHeaderModifier` feature and usage
- Adds a sanitization example
- Links to the HTTPListenerPolicy API reference
- Verified locally using Hugo

### References
- Feature PR: kgateway-dev#12992
- Docs issue: https://github.com/kgateway-dev/kgateway.dev/issues/584
