### PR TITLE
Fix indentation in static-mcp md

### DIFF
--- a/assets/docs/pages/agentgateway/mcp/static.md
+++ b/assets/docs/pages/agentgateway/mcp/static.md
@@ -121,11 +121,10 @@ spec:
   - name: agentgateway-proxy
     namespace: {{< reuse "docs/snippets/namespace.md" >}}  
   rules:
-  - 
-    backendRefs:
-    - name: mcp-backend
-      group: agentgateway.dev
-      kind: {{< reuse "docs/snippets/backend.md" >}}  
+    - backendRefs:
+      - name: mcp-backend
+        group: agentgateway.dev
+        kind: {{< reuse "docs/snippets/backend.md" >}}  
 EOF
 ```
 {{< /version >}}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

I found a indentation issue in static-mcp.md see https://kgateway.dev/docs/agentgateway/main/mcp/static-mcp/

```
kubectl apply -f- <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: mcp
spec:
  parentRefs:
  - name: agentgateway-proxy
    namespace: agentgateway-system  
  rules:
  - 
    backendRefs:
    - name: mcp-backend
      group: agentgateway.dev
      kind: AgentgatewayBackend  
EOF
```

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix indentation in static-mcp md
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
