### PR TITLE
Fix missing card links in topic index pages

### DIFF
--- a/content/docs/main/about/_index.md
+++ b/content/docs/main/about/_index.md
@@ -13,5 +13,6 @@ To learn more about {{< reuse "docs/snippets/kgateway.md" >}}, review the follow
   {{< card link="architecture" title="Architecture" >}}
   {{< card link="deployment-patterns" title="Deployment patterns" >}}
   {{< card link="custom-resources" title="Custom resources" >}}
+  {{< card link="proxies" title="Gateway proxies" >}}
   {{< card link="policies" title="Policies" >}}
 {{< /cards >}}

--- a/content/docs/main/about/policies/_index.md
+++ b/content/docs/main/about/policies/_index.md
@@ -6,3 +6,11 @@ next: /docs/about/policies/trafficpolicy
 ---
 
 {{< reuse "docs/pages/about/policies-index.md" >}}
+
+{{< cards >}}
+  {{< card link="trafficpolicy" title="TrafficPolicy" >}}
+  {{< card link="httplistenerpolicy" title="HTTPListenerPolicy" >}}
+  {{< card link="backendconfigpolicy" title="BackendConfigPolicy" >}}
+  {{< card link="global-attachment" title="Global policy attachment" >}}
+  {{< card link="merging" title="Policy merging" >}}
+{{< /cards >}}

--- a/content/docs/main/agentgateway/_index.md
+++ b/content/docs/main/agentgateway/_index.md
@@ -13,6 +13,9 @@ description: Use kgateway with agentgateway.
   {{< card link="inference" title="Inference routing" >}}
   {{< card link="mcp" title="MCP connectivity" >}}
   {{< card link="agent" title="Agent connectivity" >}}
+  {{< card link="rbac" title="CEL-based RBAC" >}}
+  {{< card link="llm/guardrail-api" title="Guardrail Webhook API" >}}
+  {{< card link="llm/observability" title="View metrics and logs" >}}
   {{< card link="routes" title="Routes" >}}
   {{< card link="nacks" title="Monitoring agentgateways for NACKs" >}}
 {{< /cards >}}

--- a/content/docs/main/install/_index.md
+++ b/content/docs/main/install/_index.md
@@ -11,4 +11,5 @@ Learn how to install kgateway.
   {{< card link="argocd" title="Argo CD" >}}
   {{< card link="sample-app" title="Sample app" >}}
   {{< card link="advanced" title="Advanced settings" >}}
+  {{< card link="tls" title="TLS encryption" >}}
 {{< /cards >}}

--- a/content/docs/main/security/_index.md
+++ b/content/docs/main/security/_index.md
@@ -13,6 +13,7 @@ For example, you might use HTTPS listeners for external client connections, enfo
 {{< cards >}}
   {{< card link="access-logging" title="Access logging" >}}
   {{< card link="cors" title="CORS" >}}
+  {{< card link="csrf" title="CSRF" >}}
   {{< card link="external-auth" title="Bring your own external auth" >}}
   {{< card link="ratelimit" title="Rate limiting" >}}
   {{< card link="backend-tls" title="Backend TLS" >}}

--- a/content/docs/main/setup/_index.md
+++ b/content/docs/main/setup/_index.md
@@ -7,7 +7,9 @@ Review your options for configuring gateway proxies and the HTTP or HTTPS listen
 
 {{< cards >}}
   {{< card link="default" title="Default gateway proxy setup" >}}
-  {{< card link="customize" title="Gateway customization" >}}
+  {{< card link="customize" title="Customize the proxy" >}}
+  {{< card link="selfmanaged" title="Self-managed gateways (BYO)" >}}
+  {{< card link="http10" title="HTTP/1.0 and HTTP/0.9" >}}
   {{< card link="listeners" title="Listeners" >}}
   {{< card link="hpa" title="Horizontal Pod Autoscaling (HPA)" >}}
 {{< /cards >}}

--- a/content/docs/main/traffic-management/transformations/_index.md
+++ b/content/docs/main/traffic-management/transformations/_index.md
@@ -12,6 +12,7 @@ Mutate and transform requests and responses before forwarding them to the destin
   {{< card link="redirect-url" title="Create redirect URLs" >}}
   {{< card link="change-response-status" title="Change response status" >}}
   {{< card link="update-response-body" title="Update response body" >}}
+  {{< card link="templating-language" title="Templating language" >}}
 {{< /cards >}}
 
 ## Known limitations


### PR DESCRIPTION
# Description

This PR adds the missing card links in multiple docs `_index.md` pages so users can navigate sub-topics directly from the topic overview pages.
Fixes #440

# Change Type

/kind documentation
/kind fix

# Changelog

```release-note
add missing card links to topic index pages for easier navigation.
```

# Additional Notes

Verified locally using `hugo` / `hugo -D` and checked that the new card links render correctly.
