### PR TITLE
fix: correct broken Inference Extension links in AI Gateway documentation

### DIFF
--- a/content/docs/envoy/2.0.x/ai/_index.md
+++ b/content/docs/envoy/2.0.x/ai/_index.md
@@ -21,5 +21,5 @@ Explore what you can do with AI Gateway in the following guides.
   {{< card link="prompt-guards" title="Prompt guards" >}}
   {{< card link="observability" title="AI Gateway metrics" >}}
   {{< card link="cleanup" title="Cleanup" >}}
-  {{< card link="/docs/integrations/inference-extension" title="Inference Extension for local LLMs" icon="bookmark" >}}
+  {{< card link="../integrations/inference-extension" title="Inference Extension for local LLMs" icon="bookmark" >}}
 {{< /cards >}}

--- a/content/docs/envoy/latest/ai/_index.md
+++ b/content/docs/envoy/latest/ai/_index.md
@@ -19,5 +19,5 @@ Explore what you can do with AI Gateway in the following guides.
   {{< card link="prompt-guards" title="Prompt guards" >}}
   {{< card link="observability" title="AI Gateway metrics" >}}
   {{< card link="cleanup" title="Cleanup" >}}
-  {{< card link="/docs/integrations/inference-extension" title="Inference Extension for local LLMs" icon="bookmark" >}}
+  {{< card link="https://agentgateway.dev/docs/kubernetes/latest/inference/" title="Inference Extension for local LLMs" icon="external-link" >}}
 {{< /cards >}}


### PR DESCRIPTION
# Description

Fixed broken "Inference Extension for local LLMs" links in the AI Gateway documentation that were causing 404 errors.

**What changed:**
- Updated `2.0.x/ai/_index.md` to use relative path instead of absolute path for correct version routing
- Updated `latest/ai/_index.md` to point to the external agentgateway inference documentation (where the feature now lives)

**Motivation:**
The absolute path `/docs/integrations/inference-extension` was breaking version-specific routing in 2.0.x, and the link in latest/main was pointing to a non-existent page since Inference Extension functionality has been migrated to agentgateway.

**Related issues:** Fixes #441

# Change Type
```
/kind fix
/kind documentation
```

# Changelog
```release-note
Fix broken Inference Extension documentation links in AI Gateway section. 2.0.x now correctly links to version-specific docs, and latest redirects to agentgateway inference documentation.
```

# Additional Notes

Verified that the external agentgateway URL (https://agentgateway.dev/docs/kubernetes/latest/inference/) returns 200 OK. No changes needed for `main` version as it already has correct structure.