### PR TITLE
security: upgrade solo.io links from HTTP to HTTPS

### DIFF
--- a/content/blog/guide-to-installing-kgateway.md
+++ b/content/blog/guide-to-installing-kgateway.md
@@ -144,7 +144,7 @@ Unlike a traditional Ingress API setup, no data-plane proxy (Envoy, in this case
 
 We have laid the groundwork for creating and programming a Gateway resource, deploying a sample application, and defining routing and policy configurations for your workloads. In the next blog, we will show you exactly how to accomplish this using kgateway.
 
-In the meantime, we encourage you to explore the [kgateway documentation concepts](https://kgateway.dev/docs/about/), recap the concepts in the [demo](https://youtu.be/eGo8uJDsBEc?si=kIqltssNdFIRIh5g) video below or get hands on and test out the concepts in the free technical lab on [installing kgateway](http://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community).
+In the meantime, we encourage you to explore the [kgateway documentation concepts](https://kgateway.dev/docs/about/), recap the concepts in the [demo](https://youtu.be/eGo8uJDsBEc?si=kIqltssNdFIRIh5g) video below or get hands on and test out the concepts in the free technical lab on [installing kgateway](https://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community).
 
 Thanks to the standards set forth by the Gateway API specification, you’d be surprised how intuitive it is to get started. 
 Stay tuned for the next part of the series writeup!

--- a/data/labs.yaml
+++ b/data/labs.yaml
@@ -1,22 +1,22 @@
 - title: How to install kgateway - an open implementation of K8s Gateway API
   description: Learn how to install kgateway and apply Kubernetes Gateway API Custom Resource Definitions (CRDs)
-  href: http://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Understanding the basics of Kubernetes Gateway API with kgateway
   description: Learn to configure Gateway and HTTPRoute resources and expose a service with kgateway.
-  href: http://www.solo.io/resources/lab/understanding-the-basics-of-kubernetes-gateway-api-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/understanding-the-basics-of-kubernetes-gateway-api-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Configuring kgateway to expose a cluster service over HTTPS
   description: Learn to secure your services with Gateway API and retrofit your configuration to enforce HTTPS traffic with kgateway.
-  href: http://www.solo.io/resources/lab/configure-https-with-the-gateway-api-and-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/configure-https-with-the-gateway-api-and-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Configuring gateways across multiple teams with kgateway
   description: Learn how to configure a shared gateway for multiple development team using the Kubernetes Gateway API
-  href: http://www.solo.io/resources/lab/configuring-gateways-across-multiple-teams-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/configuring-gateways-across-multiple-teams-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Exploring HTTPRoute resource configurations with kgateway
   description: Learn HTTP traffic management features including request matching, url rewriting, traffic splitting and header modification
-  href: http://www.solo.io/resources/lab/exploring-httproute-resource-configurations-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/exploring-httproute-resource-configurations-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Gateway API support for service mesh with kgateway
   description: See how Kubernetes Gateway API supports service mesh with kgateway to manage and control internal east-west traffic with your system
@@ -60,7 +60,7 @@
 
 - title: Kgateway as a waypoint
   description: Learn how to use kgateway as a waypoint with Istio's ambient mode to manage east-west traffic between workloads
-  href: http://www.solo.io/resources/lab/kgateway-lab-kgateway-as-a-waypoint?&utm_source=website&utm_medium=lab
+  href: https://www.solo.io/resources/lab/kgateway-lab-kgateway-as-a-waypoint?&utm_source=website&utm_medium=lab
 
 - title: Integrating kgateway with Istio at ingress
   description: Explore how to integrate kgateway's ingress gateway with Ambient Mesh to enable automatic mTLS between ingress gateway and backend workloads

--- a/layouts/shortcodes/learning-paths-list.html
+++ b/layouts/shortcodes/learning-paths-list.html
@@ -48,7 +48,7 @@
                   {{ end }}
                   {{ if .lab }}
                     {{ if or (.video) (.youtube) }}|{{ end }}
-                    <a href="http://www.solo.io/resources/lab/{{ .lab }}" class="text-primary-bg">Lab</a>
+                    <a href="https://www.solo.io/resources/lab/{{ .lab }}" class="text-primary-bg">Lab</a>
                   {{ end }}
                 </li>
               {{ end}}


### PR DESCRIPTION
## Motivation
This change addresses a security concern where multiple Solo.io laboratory links throughout the documentation were using insecure HTTP protocol instead of HTTPS. Using HTTP for external links poses several risks:
- **Security vulnerability**: Unencrypted HTTP connections are susceptible to man-in-the-middle attacks
- **SEO impact**: Modern search engines penalize HTTP links and prefer HTTPS
- **User trust**: Modern browsers display "Not Secure" warnings for HTTP sites
- **Industry standards**: HTTPS is the current standard for all web traffic

## What Changed
Systematically upgraded all Solo.io laboratory URLs from `http://www.solo.io/` to `https://www.solo.io/` across the codebase:
- Updated 7 hardcoded lab URLs in the [data/labs.yaml](cci:7://file:///c:/Users/karns/Documents/GitHub/kgateway.dev/data/labs.yaml:0:0-0:0) configuration file
- Updated the Hugo shortcode template that dynamically generates lab links
- Updated the blog post that references a Solo.io lab

## Impact
- **9 insecure HTTP links** converted to secure HTTPS
- **Zero breaking changes** - all URLs remain valid and functional
- Improved security posture and SEO compliance

# Change Type

/kind security
/kind cleanup
/kind documentation

# Changelog

```release-note
security: upgraded all Solo.io laboratory links from HTTP to HTTPS for enhanced security and SEO compliance