### PR TITLE
docs(agentgateway): Add AgentgatewayPolicy long-form docs+accessLog/backend TLS /transformation examples

### DIFF
--- a/content/docs/agentgateway/agentgateway-policy.md
+++ b/content/docs/agentgateway/agentgateway-policy.md
@@ -12,6 +12,9 @@ author: Gaurav Singh
 
 > Why this matters: `AgentgatewayPolicy` centralizes security, observability, and traffic transformation for AI traffic (LLMs, MCP, agent-to-agent) and is the recommended way to configure agentgateway in Kubernetes.
 
+**About this doc**  
+I created these examples while working with agentgateway and Kubernetes; they are intentionally concise so you can copy/paste them into your environment and adapt them quickly. Please review and replace placeholder values (namespace, names, certificates) before applying them in production.
+
 ---
 
 ## Short conceptual summary

--- a/content/docs/agentgateway/examples/access-logging-agentgatewaypolicy.yaml
+++ b/content/docs/agentgateway/examples/access-logging-agentgatewaypolicy.yaml
@@ -1,3 +1,4 @@
+# This is an example — replace name/namespace values for your cluster.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:

--- a/content/docs/agentgateway/examples/backend-tls-tcp-agentgatewaypolicy.yaml
+++ b/content/docs/agentgateway/examples/backend-tls-tcp-agentgatewaypolicy.yaml
@@ -1,3 +1,4 @@
+# This is an example — replace name/namespace values for your cluster.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -10,18 +11,12 @@ spec:
       name: my-llm-route
   backend:
     tls:
-      root: |-
-        -----BEGIN CERTIFICATE-----
-        MIID...your-root-cert...
-        -----END CERTIFICATE-----
-      cert: |-
-        -----BEGIN CERTIFICATE-----
-        ...
-        -----END CERTIFICATE-----
-      key: |-
-        -----BEGIN PRIVATE KEY-----
-        ...
-        -----END PRIVATE KEY-----
+      # Reference a Kubernetes Secret containing TLS materials (recommended).
+      # Example: secretRef points to a secret with keys "tls.crt" and "tls.key"
+      secretRef:
+        name: my-llm-backend-tls
+        namespace: agentgateway-system
+      # insecure: false prevents skipping verification (set to true only for testing)
       insecure: false
     tcp:
       keepalive:

--- a/content/docs/agentgateway/examples/transformation-agentgatewaypolicy.yaml
+++ b/content/docs/agentgateway/examples/transformation-agentgatewaypolicy.yaml
@@ -1,3 +1,4 @@
+# This is an example-replace name/namespace values for your cluster.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:


### PR DESCRIPTION
Closes: #471

Summary
-------
This PR adds a long-form documentation page for the `AgentgatewayPolicy` CRD and includes three example manifests demonstrating:

  * Access logging to OpenTelemetry (OTLP) (`examples/access-logging-agentgatewaypolicy.yaml`)
  * Backend TLS + TCP keepalive configuration using a Kubernetes Secret reference (`examples/backend-tls-tcp-agentgatewaypolicy.yaml`)
  * Request/response transformation and prompt-guard response masking (`examples/transformation-agentgatewaypolicy.yaml`)

What I changed
--------------
- Added `content/docs/agentgateway/agentgateway-policy.md` -- long-form guide, schema excerpt, conceptual notes, and three example sections.
- Added example manifests in `content/docs/agentgateway/examples/`:
  - `access-logging-agentgatewaypolicy.yaml`
  - `backend-tls-tcp-agentgatewaypolicy.yaml` (uses `secretRef`; includes security note)
  - `transformation-agentgatewaypolicy.yaml`
- Added short safety notes in each example: “This is an example -- replace name/namespace/cert values for your cluster.”
- Ensured frontmatter includes `title`, `toc: true`, `publishDate`, and `author`.
- Verified local build: `hugo server -D` runs and `hugo --minify` completes locally.
- All commits include DCO signoff (`Signed-off-by: Gaurav<gauravsingh70800@gmail.com>`).

Why
---
`AgentgatewayPolicy` replaces the older `TrafficPolicy` and adds first-class support for access logs, backend configuration (TLS/TCP), and transformations. These docs provide copy/paste examples and security guidance to help users adopt the new policy.

How I validated
--------------
- Built the site locally (Hugo + Go installed). The page renders at: `/docs/agentgateway/agentgateway-policy/`.
- Confirmed no private keys or real certificates in repo (TLS example references a Kubernetes Secret).
- Confirmed commit DCO signoff.

Notes for reviewers
-------------------
- These are docs + example manifests only; no code changes to the agentgateway runtime.
- Examples use placeholders and explicitly instruct users to replace `name`/`namespace`/secret values for their clusters.
- If you prefer the examples in a different path (e.g., `static/examples/` or a new `examples/` top-level folder), I can move them in a followup commit.

Testing locally
---------------
1. Clone my branch and run:
2. 2. Optional: `hugo --minify` to verify a production-like build.

Thank you --happy to iterate on wording, namespace choices, or to add a tiny CI workflow that runs `hugo --minify` if maintainers want a build check in the PR.