### PR TITLE
fix: scripts/generate-ref-docs.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ resources/
 !content/resources/
 !layouts/resources/
 
+# Python cache
+__pycache__/
+
 # macOS system files
 .DS_Store

--- a/scripts/generate-ref-docs.py
+++ b/scripts/generate-ref-docs.py
@@ -481,21 +481,19 @@ def generate_api_docs(version, link_version, url_path, kgateway_dir='kgateway'):
             # Apply post-processing
             _post_process_api_docs(api_file)
             
-            # Inject missing type definitions
-            agentgateway_api_dir = f'{kgateway_dir}/api/v1alpha1/agentgateway'
-            if os.path.exists(agentgateway_api_dir):
-                # Pass KUBE_VERSION to the subprocess (use the same value used for crd-ref-docs)
-                env = os.environ.copy()
-                # Use the kube_version variable set earlier in this function (line 237)
-                env['KUBE_VERSION'] = kube_version
-                result = subprocess.run([
-                    sys.executable, 'scripts/inject-missing-types.py',
-                    api_file, agentgateway_api_dir
-                ], capture_output=True, text=True, check=False, env=env)
-                if result.returncode == 0:
-                    print(f'    ✓ Injected missing types into agentgateway API docs')
-                elif result.stdout or result.stderr:
-                    print(f'    ⚠ Type injection output: {result.stdout}{result.stderr}')
+            # Inject missing type definitions from agentgateway and shared packages
+            env = os.environ.copy()
+            env['KUBE_VERSION'] = kube_version
+            for src_dir in [f'{kgateway_dir}/api/v1alpha1/agentgateway', f'{kgateway_dir}/api/v1alpha1/shared']:
+                if os.path.exists(src_dir):
+                    result = subprocess.run([
+                        sys.executable, 'scripts/inject-missing-types.py',
+                        api_file, src_dir
+                    ], capture_output=True, text=True, check=False, env=env)
+                    if result.returncode == 0:
+                        print(f'    ✓ Injected missing types from {os.path.basename(src_dir)} into agentgateway API docs')
+                    elif result.stdout or result.stderr:
+                        print(f'    ⚠ Type injection output: {result.stdout}{result.stderr}')
             
             print(f'    ✓ Generated agentgateway API docs in {api_file}')
         else:
@@ -519,21 +517,19 @@ def generate_api_docs(version, link_version, url_path, kgateway_dir='kgateway'):
             # Apply post-processing
             _post_process_api_docs(api_file)
             
-            # Inject missing type definitions
-            envoy_api_dir = f'{kgateway_dir}/api/v1alpha1/envoy'
-            if os.path.exists(envoy_api_dir):
-                # Pass KUBE_VERSION to the subprocess (use the same value used for crd-ref-docs)
-                env = os.environ.copy()
-                # Use the kube_version variable set earlier in this function (line 237)
-                env['KUBE_VERSION'] = kube_version
-                result = subprocess.run([
-                    sys.executable, 'scripts/inject-missing-types.py',
-                    api_file, envoy_api_dir
-                ], capture_output=True, text=True, check=False, env=env)
-                if result.returncode == 0:
-                    print(f'    ✓ Injected missing types into envoy API docs')
-                elif result.stdout or result.stderr:
-                    print(f'    ⚠ Type injection output: {result.stdout}{result.stderr}')
+            # Inject missing type definitions from kgateway and shared packages
+            env = os.environ.copy()
+            env['KUBE_VERSION'] = kube_version
+            for src_dir in [f'{kgateway_dir}/api/v1alpha1/kgateway', f'{kgateway_dir}/api/v1alpha1/shared']:
+                if os.path.exists(src_dir):
+                    result = subprocess.run([
+                        sys.executable, 'scripts/inject-missing-types.py',
+                        api_file, src_dir
+                    ], capture_output=True, text=True, check=False, env=env)
+                    if result.returncode == 0:
+                        print(f'    ✓ Injected missing types from {os.path.basename(src_dir)} into envoy API docs')
+                    elif result.stdout or result.stderr:
+                        print(f'    ⚠ Type injection output: {result.stdout}{result.stderr}')
             
             print(f'    ✓ Generated envoy API docs in {api_file}')
         else:

--- a/scripts/test-missing-types.py
+++ b/scripts/test-missing-types.py
@@ -61,20 +61,29 @@ if __name__ == '__main__':
     print("SPECIFIC ISSUES:")
     print("=" * 60)
     
-    # Check specific types
-    for type_name in ['BackendSimple', 'RemoteJWKS', 'RateLimitDescriptorEntry']:
+    # Check specific types that must be documented
+    failures = []
+    for type_name in ['BackendSimple', 'RemoteJWKS', 'RateLimitDescriptorEntry', 'KubernetesResourceOverlay']:
         print(f"\n{type_name}:")
         if type_name in referenced:
             print(f"  ✓ Referenced in docs")
         else:
             print(f"  ✗ Not referenced")
+            failures.append(f"{type_name} is not referenced in docs")
         if type_name in documented:
             print(f"  ✓ Has documentation section")
             if type_name in empty_structs:
                 print(f"  ⚠ But shows as empty struct (no fields)")
+                failures.append(f"{type_name} is documented as empty struct")
         else:
             print(f"  ✗ No documentation section")
+            failures.append(f"{type_name} is not documented")
 
-
-
+    if failures:
+        print(f"\n{'=' * 60}")
+        print("FAILURES:")
+        print('=' * 60)
+        for f in failures:
+            print(f"  ✗ {f}")
+        sys.exit(1)
 


### PR DESCRIPTION
# Description

scripts/generate-ref-docs.py fixes

- typo: s/envoy/kgateway/
- adds the 'shared' directory, too, and updates the test to ensure that KubernetesResourceOverlay is present in the docs

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind documentation

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
