### PR TITLE
Fix/typos and blog formatting

### DIFF
--- a/content/blog/guide-to-installing-kgateway.md
+++ b/content/blog/guide-to-installing-kgateway.md
@@ -8,10 +8,10 @@ excludeSearch: true
 
 [kgateway](https://kgateway.dev/) is an implementation of the Kubernetes Gateway API developed by Solo.io and donated to the CNCF at KubeCon Salt Lake City in Fall 2024. It’s designed to program Envoy, the CNCF's popular cloud-native proxy, offering modern traffic management across Kubernetes (and even non-Kubernetes) workloads. For more information around the motivations behind the kgateway project, Lin Sun recently [penned a blog](https://kgateway.dev/blog/advancing-open-source-gateways/) providing an update on the project.
 
-To help the community learn about Gateway API, we plan to publish [blogs](http://kgateway.dev/blog), [videos](https://kgateway.dev/resources/videos/), and [hands-on labs](https://kgateway.dev/resources/labs/) using kgateway as a reference implementation example. Here is what you can expect from this series:
+To help the community learn about Gateway API, we plan to publish [blogs](https://kgateway.dev/blog), [videos](https://kgateway.dev/resources/videos/), and [hands-on labs](https://kgateway.dev/resources/labs/) using kgateway as a reference implementation example. Here is what you can expect from this series:
 
-* Starting with a Gateway API “explainer” series, we will dive into the concepts of the specification, focusing on the “why” behind the decisions made in Gateway API, starting with this blog that dives into the installation of the control plane components
-* Next we will explore data plane concepts, how to configure gateways and routes to complete an end-to-end example that demonstrates how the control plane and data plane work together
+* Starting with a Gateway API “explainer” series, we will dive into the concepts of the specification, focusing on the “why” behind the decisions made in Gateway API, starting with this blog that dives into the installation of the control plane components.
+* Next we will explore data plane concepts, how to configure gateways and routes to complete an end-to-end example that demonstrates how the control plane and data plane work together.
 * We’ll then highlight the fundamental building blocks common to every Gateway API implementation, to establish a solid grasp of the standard features and practices.
 * Moving forward, we’ll discuss the unique capabilities and advanced functionality offered by kgateway, including special extensions and policy attachments.
 * Finally, we’ll wrap up by examining how kgateway integrates with service mesh and AI-based features, offering insights into where the technology is headed.
@@ -35,17 +35,17 @@ The Gateway API community provides guidance in their [versioning](https://gatewa
 kgateway's instructions steer us to the experimental channel, which enables us to quickly
 iterate and test the latest and greatest features. Currently this includes CRDs that are still deemed to be "alpha" quality such as TCPRoute, TLSRoute, UDPRoute, and others.
 
-```yaml
+```sh
 kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.2.1"
 ```
 
 We can look at the associated API resources just applied to review which resources are stable vs alpha:
 
-```yaml
+```sh
 kubectl api-resources --api-group=gateway.networking.k8s.io
 ```
 
-```yaml
+```text
 NAME                 SHORTNAMES   APIVERSION                           NAMESPACED   KIND
 backendlbpolicies    blbpolicy    gateway.networking.k8s.io/v1alpha2   true         BackendLBPolicy
 backendtlspolicies   btlspolicy   gateway.networking.k8s.io/v1alpha3   true         BackendTLSPolicy
@@ -63,7 +63,7 @@ Next, we’ll install the kgateway controller. This component is responsible for
 
 Installation consists of deploying the following Helm charts for the CRD and kgateway control plane, such as with the v2.0.0 release in the following commands. 
 
-```yaml
+```sh
 helm upgrade -i --create-namespace --namespace kgateway-system --version v2.0.0 kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 
 helm upgrade -i --namespace kgateway-system --version v2.0.0 kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway
@@ -71,22 +71,22 @@ helm upgrade -i --namespace kgateway-system --version v2.0.0 kgateway oci://cr.k
 
 Once installation is complete, we can take a peek at kgateway and its additional extensions and policy attachments that support a wider set of advanced traffic management and configuration capabilities.
 
-```yaml
+```sh
 kubectl api-resources --api-group=gateway.kgateway.dev
 ```
 
-```yaml
+```text
 NAME                   SHORTNAMES   APIVERSION                      NAMESPACED   KIND
 directresponses        dr           gateway.kgateway.dev/v1alpha1   true         DirectResponse
 gatewayparameters      gwp          gateway.kgateway.dev/v1alpha1   true         GatewayParameters
 httplistenerpolicies   hlp          gateway.kgateway.dev/v1alpha1   true         HTTPListenerPolicy
-TrafficPolicies          rp           gateway.kgateway.dev/v1alpha1   true         TrafficPolicy
+trafficpolicies        rp           gateway.kgateway.dev/v1alpha1   true         TrafficPolicy
 upstreams              up           gateway.kgateway.dev/v1alpha1   true         Upstream
 ```
 
 We can also inspect the default [GatewayClass](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/) that gets created as part of the Helm installation:
 
-```yaml
+```sh
 kubectl get gatewayclass kgateway -o yaml | bat -l yaml
 ```
 
@@ -132,7 +132,7 @@ The GatewayClass immediately solves a problem that existed with the legacy Ingre
 
 After installing kgateway, let’s confirm that it’s running properly in the kgateway-system namespace. Should you encounter any issues, check the controller logs for more details.
 
-```yaml
+```sh
 % kubectl get pods -n kgateway-system
 NAME                        READY   STATUS    RESTARTS   AGE
 kgateway-6848684bc9-t4d78   1/1     Running   0          10m
@@ -144,7 +144,7 @@ Unlike a traditional Ingress API setup, no data-plane proxy (Envoy, in this case
 
 We have laid the groundwork for creating and programming a Gateway resource, deploying a sample application, and defining routing and policy configurations for your workloads. In the next blog, we will show you exactly how to accomplish this using kgateway.
 
-In the meantime, we encourage you to explore the [kgateway documentation concepts](https://kgateway.dev/docs/about/), recap the concepts in the [demo](https://youtu.be/eGo8uJDsBEc?si=kIqltssNdFIRIh5g) video below or get hands on and test out the concepts in the free technical lab on [installing kgateway](http://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community).
+In the meantime, we encourage you to explore the [kgateway documentation concepts](https://kgateway.dev/docs/about/), recap the concepts in the [demo](https://youtu.be/eGo8uJDsBEc?si=kIqltssNdFIRIh5g) video below or get hands on and test out the concepts in the free technical lab on [installing kgateway](https://www.solo.io/resources/lab/install-kgateway-open-source-implementation-of-the-gateway-api?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community).
 
 Thanks to the standards set forth by the Gateway API specification, you’d be surprised how intuitive it is to get started. 
 Stay tuned for the next part of the series writeup!

--- a/content/docs/envoy/2.0.x/install/sample-app.md
+++ b/content/docs/envoy/2.0.x/install/sample-app.md
@@ -113,7 +113,7 @@ Create an API gateway with an HTTP listener by using the {{< reuse "docs/snippet
 
 Now that you have an app and a gateway proxy, you can create a route to access the app.
 
-1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `wwww.example.com` domain. 
+1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `www.example.com` domain. 
    
    ```yaml
    kubectl apply -f- <<EOF

--- a/content/docs/envoy/latest/install/sample-app.md
+++ b/content/docs/envoy/latest/install/sample-app.md
@@ -113,7 +113,7 @@ Create an API gateway with an HTTP listener by using the {{< reuse "docs/snippet
 
 Now that you have an app and a gateway proxy, you can create a route to access the app.
 
-1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `wwww.example.com` domain. 
+1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `www.example.com` domain. 
    
    ```yaml
    kubectl apply -f- <<EOF

--- a/content/docs/envoy/main/install/sample-app.md
+++ b/content/docs/envoy/main/install/sample-app.md
@@ -113,7 +113,7 @@ Create an API gateway with an HTTP listener by using the {{< reuse "docs/snippet
 
 Now that you have an app and a gateway proxy, you can create a route to access the app.
 
-1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `wwww.example.com` domain. 
+1. Create an HTTPRoute resource to expose the httpbin app on the Gateway. The following example exposes the app on the `www.example.com` domain. 
    
    ```yaml
    kubectl apply -f- <<EOF


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

This PR addresses several documentation issues found across the codebase:

- **Fixed Typo in Sample App Guide**: Corrected `wwww.example.com` to `www.example.com` in [content/docs/envoy/main/install/sample-app.md](cci:7://file:///c:/Users/karns/Documents/GitHub/kgateway.dev/content/docs/envoy/main/install/sample-app.md:0:0-0:0), [content/docs/envoy/2.0.x/install/sample-app.md](cci:7://file:///c:/Users/karns/Documents/GitHub/kgateway.dev/content/docs/envoy/2.0.x/install/sample-app.md:0:0-0:0), and [content/docs/envoy/latest/install/sample-app.md](cci:7://file:///c:/Users/karns/Documents/GitHub/kgateway.dev/content/docs/envoy/latest/install/sample-app.md:0:0-0:0). This prevents user confusion during initial setup.
- **Polished `Guide to Installing kgateway` Blog**:
    - Updated insecure `http` links to `https` for `kgateway.dev` and `solo.io`.
    - Changed code blocks from [yaml](cci:7://file:///c:/Users/karns/Documents/GitHub/kgateway.dev/hugo.yaml:0:0-0:0) to `sh` or `text` for better syntax highlighting where appropriate.
    - Fixed minor typos in output examples (`TrafficPolicies` -> `trafficpolicies`).
    - Improved formatting consistency in bullet points.

# Change Type

/kind documentation
/kind fix

# Changelog

```release-note
NONE