### PR TITLE
Remove versioning from sidebar

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,7 +16,6 @@ assignees: ''
 - [ ] In `content/docs`, create the new `main` by making a copy of the current main directory. Rename the directories appropriately. For example, the old main is copied to a new `main`, the old main becomes `latest`, and the old latest becomes a `2.x.x` version.
 - [ ] In the `hugo.yaml` file, update the `versions` to include the new minor version as main, the previous main as latest, and the previous latest as its version.
 - [ ] In the `versions.json` file, update the `versions` to include the new minor version as main, the previous main as latest, and the previous latest as its version.
-- [ ] Update the `layouts/partials/sidebar.html` partial so that the versions render in the sidebar, as well as check for any other layouts that might have hardcoded versions.
 - [ ] Retire any version older than `n-3` (remove the directory and version from the `hugo.yaml` file)
 - [ ] Update the version conrefs in the `assets/docs/versions` directory. Often, there is not a release for the next version, so you might have to use the same for latest and main.
 - [ ] Add the release date to the version table in `assets/docs/pages/reference/versions.md`, and remove any retired versions.

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -17,14 +17,12 @@
   {{- $section := "" -}}
   {{- $isVersionedDocs := false -}}
   
-  {{- /* Check if we're in a versioned docs section */ -}}
+  {{- /* Check if we're in a versioned docs section: /docs/<section>/<version>/... */ -}}
+  {{- /* No hardcoded version list: any such path is treated as versioned; GetPage decides if the section exists */ -}}
   {{- if and (ge (len $segments) 4) (eq (index $segments 1) "docs") -}}
     {{- $section = index $segments 2 -}}
-    {{- $versionCandidate := index $segments 3 -}}
-    {{- if or (eq $versionCandidate "2.0.x") (eq $versionCandidate "2.1.x") (eq $versionCandidate "latest") (eq $versionCandidate "main") -}}
-      {{- $currentVersion = $versionCandidate -}}
-      {{- $isVersionedDocs = true -}}
-    {{- end -}}
+    {{- $currentVersion = index $segments 3 -}}
+    {{- $isVersionedDocs = true -}}
   {{- end -}}
 
   {{- if $isVersionedDocs -}}


### PR DESCRIPTION
We don't need separate versioning, follow up to https://github.com/kgateway-dev/kgateway.dev/pull/686/

/kind documentation


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```