### PR TITLE
docs(argocd): enable ServerSideApply in example Application manifest

### DIFF
--- a/assets/docs/snippets/argocd.md
+++ b/assets/docs/snippets/argocd.md
@@ -58,6 +58,7 @@
          selfHeal: true 
        syncOptions:
        - CreateNamespace=true 
+       - ServerSideApply=true
    EOF
    ```
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The Argo CD example manifest for installing kgateway CRDs uses client-side apply by default. When Argo CD applies large CRD manifests, the API server may reject the request with an error like:

```
metadata.annotations: Too long: may not be more than 262144 bytes.
```

This can happen because client-side apply stores the full manifest in the `kubectl.kubernetes.io/last-applied-configuration` annotation, which may exceed Kubernetes' 256 KiB annotation size limit for large CRDs.

<img width="1132" height="456" alt="image" src="https://github.com/user-attachments/assets/26bdb1ed-ce29-4c86-a94d-4dfe69021588" />

<img width="1037" height="543" alt="image" src="https://github.com/user-attachments/assets/6483d7c5-436c-45e1-95d1-21b83a94a3d6" />


This PR updates the example `Application` manifest to enable server-side apply:

```yaml
syncOptions:
- ServerSideApply=true
- CreateNamespace=true
```

Using server-side apply avoids storing the full manifest in the `last-applied-configuration` annotation and prevents this error when syncing large CRDs.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!-- Any extra context or edge cases for reviewers. -->

- Kubernetes v1.33.5
- argocd v3.3.2
- kgateway-crds helm chart v2.2.1

