### PR TITLE
Update ingress2gateway migration docs for v0.5.0

### DIFF
--- a/content/docs/envoy/main/migrate/_index.md
+++ b/content/docs/envoy/main/migrate/_index.md
@@ -10,7 +10,7 @@ Welcome to the documentation for migrating from Ingress to **Gateway API** and *
 [Kubernetes ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway) with the following additional features:
 
 - **Expanded Ingress NGINX Support:** Converts a wide range of Ingress NGINX-specific annotations, e.g. session affinity, authentication,
-  rate limiting, CORS, etc.
+  rate limiting, CORS, TLS passthrough, service-upstream, and backend protocol hints.
 - **Kgateway Emitter Support:** Generates Gateway API and kgateway-specific resources, e.g. TrafficPolicy, BackendConfigPolicy, etc.
 
 [This upstream issue](https://github.com/kgateway-dev/ingress2gateway/issues/54) tracks merging these features into the Kubernetes ingress2gateway project.
@@ -48,19 +48,44 @@ of the Ingress before converting.
 
 ## Common workflows
 
-1. Convert a file and write output to a directory.
+1. Convert Ingresses from the namespace in your current kubeconfig context.
 
     ```bash
-    ingress2gateway print   --providers=ingress-nginx   --emitter=kgateway   --input-file ./ingress.yaml   --output-dir ./out
+    ingress2gateway print \
+      --providers=ingress-nginx \
+      --emitter=kgateway
     ```
 
-2. Convert a folder of YAML files.
+2. Convert one or more manifest files.
 
     ```bash
-    ingress2gateway print   --providers=ingress-nginx   --emitter=kgateway   --input-dir ./manifests   --output-dir ./out
+    ingress2gateway print \
+      --providers=ingress-nginx \
+      --emitter=kgateway \
+      --input-file ./ingress.yaml \
+      --input-file ./more-ingresses.yaml
     ```
 
-3. Check the tool version.
+3. Select a custom Ingress NGINX class.
+
+    ```bash
+    ingress2gateway print \
+      --providers=ingress-nginx \
+      --emitter=kgateway \
+      --ingress-nginx-ingress-class=internal-nginx
+    ```
+
+4. Include experimental Gateway API fields when your migration needs them.
+
+    ```bash
+    ingress2gateway print \
+      --providers=ingress-nginx \
+      --emitter=kgateway \
+      --allow-experimental-gw-api \
+      --input-file ./ingress.yaml
+    ```
+
+5. Check the tool version.
 
     ```bash
     ingress2gateway version

--- a/content/docs/envoy/main/migrate/_index.md
+++ b/content/docs/envoy/main/migrate/_index.md
@@ -75,7 +75,7 @@ of the Ingress before converting.
       --ingress-nginx-ingress-class=internal-nginx
     ```
 
-4. Include experimental Gateway API fields when your migration needs them.
+4. The CLI also exposes `--allow-experimental-gw-api` for builds and features that use experimental Gateway API fields.
 
     ```bash
     ingress2gateway print \

--- a/content/docs/envoy/main/migrate/emitters/kgateway/_index.md
+++ b/content/docs/envoy/main/migrate/emitters/kgateway/_index.md
@@ -24,21 +24,23 @@ This command:
 
 1. Reads the kubeconfig file to extract cluster credentials and the current active namespace.
 2. Searches for ingress-nginx resources in that namespace.
-3. Converts them to Gateway API resources (currently only Gateways and HTTPRoutes).
+3. Converts them to Gateway API resources plus any required kgateway-specific resources.
 
 ## Options
 
 ### `print` command
 
-| Flag           | Default Value           | Required | Description                                                  |
-| -------------- | ----------------------- | -------- | ------------------------------------------------------------ |
-| all-namespaces | False                   | No       | If present, list the requested objects across all namespaces. Namespace in the current context is ignored even if specified with --namespace. |
-| input-file     |                         | No       | Path to the manifest file. When set, the tool reads ingresses from the file instead of from the cluster. Supported files are yaml and json. |
-| namespace      |                         | No       | If present, the namespace scope for the invocation.           |
-| output         | yaml                    | No       | The output format, either yaml or json.                       |
-| providers      |  | Yes       | Comma-separated list of providers (only ingress-nginx is supported in this downstream). |
-| emitter      | standard | No       | The emitter to use for generating Gateway API resources (supported values: standard, kgateway). |
-| kubeconfig     |                         | No       | The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file. |
+| Flag | Short | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `all-namespaces` | `-A` | `false` | No | List matching resources across all namespaces. Ignored when `--input-file` is used. |
+| `allow-experimental-gw-api` |  | `false` | No | Include experimental Gateway API fields in the generated output. |
+| `emitter` |  | `standard` | No | The emitter to use for generating Gateway API resources. |
+| `input-file` |  |  | No | Path to one or more manifest files. Repeat the flag to read multiple files instead of reading from the cluster. |
+| `kubeconfig` |  |  | No | The kubeconfig file to use when reading from the cluster. |
+| `namespace` | `-n` |  | No | Restrict cluster reads to a namespace. |
+| `no-color` |  | `false` | No | Disable ANSI color codes in CLI output. |
+| `output` | `-o` | `yaml` | No | Output format. One of `yaml`, `json`, or `kyaml`. |
+| `providers` |  |  | Yes | Comma-separated list of providers. Use `ingress-nginx` for this emitter. |
 
 ## Conversion of Ingress resources to Gateway API
 
@@ -121,10 +123,12 @@ routing rules.
 - `nginx.ingress.kubernetes.io/session-cookie-secure`: Sets the Secure flag on the cookie. Maps to `BackendConfigPolicy.spec.loadBalancer.ringHash.hashPolicies[].cookie.secure`.
 - `nginx.ingress.kubernetes.io/service-upstream`: When set to `"true"`, configures Kgateway to route to the Service’s cluster IP (or equivalent static host) instead of individual Pod IPs. For each covered Service, the emitter creates a `Backend` resource with `spec.type: Static` and rewrites the corresponding `HTTPRoute.spec.rules[].backendRefs[]` to reference that `Backend` (group `gateway.kgateway.dev`, kind `Backend`).
 - `nginx.ingress.kubernetes.io/backend-protocol`: Indicates the L7 protocol that is used to communicate with the proxied backend.
+  - This annotation affects upstream protocol selection only. It does **not** cause ingress2gateway to emit a `GRPCRoute`.
   - **Supported values (mapped):** `GRPC`, `GRPCS`
     - If `service-upstream: "true"` is also set for the same Service backend, the emitter sets `spec.static.appProtocol: grpc` on the generated `Backend`.
     - Otherwise, the emitter does **not** create or modify Kubernetes `Service` resources. Instead, it emits an **INFO** notification with a `kubectl patch`
       command to update the existing Service port with `appProtocol: grpc`.
+    - Generated routes remain `HTTPRoute` resources. This annotation only influences backend-facing configuration.
   - **Values treated as default HTTP/1.x (no-op):** `HTTP`, `HTTPS`, `AUTO_HTTP`
   - **Unsupported values (rejected by provider):** `FCGI` (and others)
   - **Safety note:** Because emitting Service manifests could overwrite user-managed Service configuration, ingress2gateway intentionally avoids generating
@@ -149,7 +153,7 @@ routing rules.
 
 ### Access Logging
 
-- `nginx.ingress.kubernetes.io/enable-access-log`: If enabled, creates an HTTPListenerPolicy that configures a basic policy for Envoy access logging. Maps to `HTTPListenerPolicy.spec.accessLog[].fileSink`. This can be further customized as needed, see [docs](https://kgateway.dev/docs/envoy/2.0.x/security/access-logging/).
+- `nginx.ingress.kubernetes.io/enable-access-log`: If enabled, creates an `HTTPListenerPolicy` that configures a basic Envoy access log policy via `HTTPListenerPolicy.spec.accessLog[].fileSink`. This can be further customized as needed; see the [access logging docs]({{< relref "../../../security/access-logging.md" >}}).
 
 ### Regex Path Matching and Rewrites
 
@@ -231,9 +235,11 @@ Currently supported:
     - `spec.static.hosts` containing a single `{host, port}` entry derived from the Service (e.g. `myservice.default.svc.cluster.local:80`).
   - Matching `HTTPRoute.spec.rules[].backendRefs[]` are rewritten to reference this `Backend` instead of the core Service.
 - `nginx.ingress.kubernetes.io/backend-protocol`:
+  - This annotation does **not** switch route generation from `HTTPRoute` to `GRPCRoute`; it only influences backend connection behavior.
   - When set to `GRPC` or `GRPCS` **and** `service-upstream: "true"` is set for the same backend, the emitter stamps `spec.static.appProtocol: grpc` on the generated `Backend`.
   - When set to `GRPC` or `GRPCS` **without** `service-upstream: "true"`, the emitter emits an **INFO** notification that includes a `kubectl patch service ...`
     command to set `spec.ports[].appProtocol` on the existing Service.
+  - Generated routes remain `HTTPRoute` resources.
   - `HTTP`, `HTTPS`, and `AUTO_HTTP` are treated as default HTTP/1.x behavior and do not emit additional config.
 
 ### Summary of Policy Types

--- a/content/docs/envoy/main/migrate/install/linux/_index.md
+++ b/content/docs/envoy/main/migrate/install/linux/_index.md
@@ -8,7 +8,7 @@ weight: 20
 1. Set your environment variables.
 
     ```bash
-    VERSION=v0.4.0
+    VERSION=v0.5.0
     OS=Linux
     # One of arm64|x86_64|i386
     ARCH=arm64

--- a/content/docs/envoy/main/migrate/install/macos/_index.md
+++ b/content/docs/envoy/main/migrate/install/macos/_index.md
@@ -8,7 +8,7 @@ weight: 10
 1. Set the environment variables.
 
     ```bash
-    VERSION=v0.4.0
+    VERSION=v0.5.0
     OS=Darwin
     # One of arm64|x86_64
     ARCH=arm64

--- a/content/docs/envoy/main/migrate/install/windows/_index.md
+++ b/content/docs/envoy/main/migrate/install/windows/_index.md
@@ -8,7 +8,7 @@ weight: 30
 1. Set your environment variables.
 
     ```bash
-    VERSION=v0.4.0
+    VERSION=v0.5.0
     OS=Windows
     # One of arm64|x86_64|i386
     ARCH=arm64

--- a/content/docs/envoy/main/migrate/providers/ingressnginx/_index.md
+++ b/content/docs/envoy/main/migrate/providers/ingressnginx/_index.md
@@ -8,9 +8,13 @@ The `ingress-nginx` provider defines the source resources to be translated, e.g.
 
 **Note:** Some annotations may be translated into kgateway resources or user-facing notifications.
 
+## Ingress Class Name
+
+To select a custom Ingress class, use `--ingress-nginx-ingress-class=ingress-nginx`. If omitted, the provider defaults to `nginx`.
+
 ## Supported Annotations
 
-The `ingress-nginx` provider currently supports an Ingress with the following annotations.
+The `ingress-nginx` provider currently supports translating the following annotations.
 
 ### Canary / Traffic Shaping
 
@@ -90,6 +94,8 @@ The `ingress-nginx` provider currently supports an Ingress with the following an
 ### Backend Protocol
 
 - `nginx.ingress.kubernetes.io/backend-protocol`: Indicates the L7 protocol that is used to communicate with the proxied backend.
+  - This annotation controls upstream protocol intent only. It does **not** change the generated route kind from `HTTPRoute`
+    to `GRPCRoute`.
   - **Supported values (recorded):** `GRPC`, `GRPCS`
     - The provider records protocol intent as policy metadata (used by implementation emitters).
     - For kgateway:
@@ -97,6 +103,7 @@ The `ingress-nginx` provider currently supports an Ingress with the following an
         on the generated `Backend`.
       - Otherwise, the kgateway emitter does **not** generate Kubernetes `Service` resources. Instead, it emits an **INFO** notification with a `kubectl patch`
         command to set `spec.ports[].appProtocol` on the existing Service.
+      - This annotation is treated as upstream protocol metadata and does not imply `GRPCRoute` projection.
   - **Values treated as default HTTP/1.x (no-op):** `HTTP`, `HTTPS`, `AUTO_HTTP`
   - **Unsupported values (rejected):** `FCGI` (and others)
   - **Safety note:** The provider does not attempt to create or mutate Kubernetes Services; implementation emitters decide how to safely project this intent.
@@ -114,6 +121,18 @@ The `ingress-nginx` provider currently supports an Ingress with the following an
 
 ---
 
+### Service Upstream
+
+- `nginx.ingress.kubernetes.io/service-upstream`: When set to `"true"`, treats a Service as a single upstream using Service IP and port semantics
+  rather than per-Endpoint Pod IPs.
+  - The provider records policy metadata describing the derived static backends and which `HTTPRoute` backendRefs the policy applies to.
+  - The kgateway emitter uses that policy to emit `Backend` resources and rewrite the affected `HTTPRoute.spec.rules[].backendRefs[]`.
+  - Backend hosts are derived as in-cluster DNS names such as `<service>.<namespace>.svc.cluster.local`.
+  - Generated backend names are derived as `<service>-service-upstream`.
+  - This applies only to core Service backendRefs with an explicit port. If a port cannot be determined, the backendRef is skipped.
+
+---
+
 ### Backend TLS
 
 - `nginx.ingress.kubernetes.io/proxy-ssl-secret`: Specifies a Secret containing client certificate (`tls.crt`), client key (`tls.key`), and optionally CA certificate (`ca.crt`) in PEM format. The secret name can be specified as `secretName` (same namespace) or `namespace/secretName`. For kgateway, this maps to `BackendConfigPolicy.spec.tls.secretRef`. **Note:** The secret must be in the same namespace as the BackendConfigPolicy.
@@ -125,6 +144,18 @@ The `ingress-nginx` provider currently supports an Ingress with the following an
 - `nginx.ingress.kubernetes.io/proxy-ssl-server-name`: **Note:** This annotation is not handled separately. In Kgateway, SNI is automatically enabled when `proxy-ssl-name` is set.
 
 **Note:** For kgateway, backend TLS configuration is applied via `BackendConfigPolicy` resources. If multiple Ingress resources reference the same Service with different backend TLS settings, ingress2gateway creates a single `BackendConfigPolicy` per Service, and conflicting settings may result in warnings.
+
+---
+
+### Access Logging
+
+- `nginx.ingress.kubernetes.io/enable-access-log`: Enables or disables access logging.
+  - In ingress-nginx, access logging is enabled by default when the annotation is not present.
+  - When the annotation is present, the provider records an explicit boolean:
+    - `"true"` enables access logging.
+    - Any other value is treated as `false`.
+  - For kgateway, when access logging is enabled, the emitter creates an `HTTPListenerPolicy` that configures a basic Envoy access log policy via
+    `HTTPListenerPolicy.spec.accessLog[].fileSink`.
 
 ---
 
@@ -158,6 +189,32 @@ The `ingress-nginx` provider currently supports an Ingress with the following an
 
 ---
 
+### SSL Passthrough (TLS Passthrough)
+
+- `nginx.ingress.kubernetes.io/ssl-passthrough`: When set to `"true"` (case-insensitive), enables TLS passthrough.
+  When enabled, TLS termination happens at the backend service rather than at the ingress controller, so the provider converts
+  the affected `HTTPRoute` into a `TLSRoute` and configures a TLS passthrough Gateway listener.
+
+Provider behavior:
+
+- Converts the generated `HTTPRoute` for the affected host or group into a `TLSRoute` in the same namespace.
+- Preserves the original `parentRefs` and `hostnames` when present.
+- Rewrites each HTTPRoute rule into a TLSRoute rule with `backendRefs`.
+- Preserves backendRef `weight` and `namespace` when set and copies `port`, defaulting to `443` when it is missing.
+- Removes the original `HTTPRoute` from the IR and adds the generated `TLSRoute`.
+
+Gateway listener behavior:
+
+- Adds a TLS passthrough listener with `protocol: TLS` and `tls.mode: Passthrough` to the parent `Gateway`.
+- Uses a default listener name of `tls-passthrough` on port `8443`.
+- If a hostname is present, uses a hostname-specific listener name, sets the port to `443`, and sets `hostname` on the listener.
+- Removes any generated HTTP listener on the `Gateway` that matches the TLSRoute hostname so that only the passthrough TLS listener remains.
+- Updates `TLSRoute.spec.parentRefs[].sectionName` to bind the route to the created passthrough listener.
+
+**Note:** With TLS passthrough enabled, backend services must accept and terminate TLS themselves.
+
+---
+
 ### Regex Path Matching and Rewrites
 
 - `nginx.ingress.kubernetes.io/use-regex`: When set to `"true"`, indicates that the paths defined on that Ingress should be treated as regular expressions.
@@ -181,7 +238,7 @@ For kgateway:
 
 ## Provider Limitations
 
-- Currently, kgateway is the only supported emitter.
+- These docs describe the `ingress-nginx` provider behavior as projected by the `kgateway` emitter.
 - Some NGINX behaviors cannot be reproduced exactly due to differences between NGINX and semantics of other proxy implementations.
 - Regex-mode is implemented by converting HTTPRoute path matches to `RegularExpression`. Some ingress-nginx details (such as case-insensitive `~*` behavior)
   may not be reproduced exactly depending on the underlying Gateway API / Envoy behavior and the patterns provided.

--- a/content/docs/envoy/main/migrate/reference/cli/_index.md
+++ b/content/docs/envoy/main/migrate/reference/cli/_index.md
@@ -6,13 +6,32 @@ This page focuses on the commands you’ll use most often.
 
 ## `print`
 
-Translates input manifests and prints generated resources.
+Translates Ingress resources and prints the generated Gateway API and kgateway resources.
+
+If you do not specify `--input-file`, the command reads from the cluster using your current kubeconfig context.
 
 Typical usage:
 
 ```bash
-ingress2gateway print   --providers=ingress-nginx   --emitter=kgateway   --input-file ./ingress.yaml
+ingress2gateway print \
+  --providers=ingress-nginx \
+  --emitter=kgateway \
+  --input-file ./ingress.yaml
 ```
+
+Common flags:
+
+| Flag | Description |
+| --- | --- |
+| `--providers=ingress-nginx` | Select the Ingress NGINX provider. |
+| `--emitter=kgateway` | Emit Gateway API and kgateway-specific resources. |
+| `--input-file ./ingress.yaml` | Read manifests from a file instead of the cluster. Repeat the flag to include multiple files. |
+| `-n`, `--namespace` | Restrict cluster reads to a namespace. |
+| `-A`, `--all-namespaces` | Read matching resources across all namespaces. |
+| `-o`, `--output` | Set the output format to `yaml`, `json`, or `kyaml`. |
+| `--allow-experimental-gw-api` | Include experimental Gateway API fields in the generated output. |
+| `--no-color` | Disable ANSI color codes in CLI output. |
+| `--ingress-nginx-ingress-class=internal-nginx` | Select a custom Ingress NGINX class. Defaults to `nginx`. |
 
 ## `version`
 


### PR DESCRIPTION
## Summary
- update the `main` ingress migration docs for ingress2gateway v0.5.0
- refresh the install snippets and CLI examples to match the current release
- document the current provider and emitter behavior for ingress class selection, service-upstream, TLS passthrough, access logging, and backend protocol handling

## Testing
- `hugo --disableKinds rss`
