### PR TITLE
test(scripts): add unit tests and CI workflow

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -1,0 +1,34 @@
+name: Script Unit Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/scripts-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/**"
+      - ".github/workflows/scripts-tests.yml"
+
+jobs:
+  python-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run script unit tests
+        run: python -m pytest scripts/tests -q

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,16 @@
 
 This directory contains scripts or other tools that are used to help improve the kgateway website and documentation.
 
+## Unit tests
+
+Unit tests for scripts in this directory live in `scripts/tests/`.
+
+Run them from the repository root:
+
+```shell
+python3 -m pytest scripts/tests -q
+```
+
 ## card-check.py
 
 A script to check the `_index.md` docs files to make sure that the cards include the right links to subpages in that directory.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,45 @@
+# Scripts
+
+This directory contains scripts and tools that help build the kgateway website and documentation.
+
+## Unit tests
+
+Unit tests for scripts in this directory live in `scripts/tests/`.
+
+Run them from the repository root:
+
+```shell
+python3 -m pytest scripts/tests -q
+```
+
+The tests cover two doc-generating scripts. These scripts build parts of the API reference documentation by reading source code and version information, then writing Markdown. If one of them has a small bug, it can quietly produce incorrect docs instead of failing loudly, so the tests focus on the helper logic that decides what content to generate.
+
+### Test helper
+
+`scripts/tests/conftest.py` is not a test file. It loads scripts such as `generate-ref-docs.py` and `generate-shared-types.py` as Python modules, because Python cannot import filenames with dashes through normal import syntax.
+
+### `generate-ref-docs.py`
+
+The tests for `generate-ref-docs.py` check that the script:
+
+- Identifies which docs versions are `2.2.x` or newer, including `main`.
+- Extracts only the requested API package section from a Markdown file that contains multiple packages.
+- Returns no package content when the requested package is missing.
+- Resolves the expected branch or release tag for a docs version.
+- Skips prerelease tags such as release candidates and beta releases when choosing the latest stable tag.
+- Calls `generate-shared-types.py` with the expected inputs when shared Go types are present.
+
+These tests replace real `git` subprocess calls with test doubles so they run quickly and do not require network access.
+
+### `generate-shared-types.py`
+
+The tests for `generate-shared-types.py` check that the script:
+
+- Reads human-written Go doc comments separately from `+kubebuilder` annotations.
+- Collects validation annotations when they are needed.
+- Parses Go structs, aliases, JSON field names, and required versus optional fields.
+- Formats links for documented types while leaving unknown types as plain text.
+- Labels enterprise duplicate type names so they do not collide with open-source types.
+- Finds documented types and detects broken type links in generated Markdown.
+
+These tests create small temporary input files and run the script logic against those fixtures.

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def load_script_module(filename: str, module_name: str):
+    module_path = SCRIPTS_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def card_check():
+    return load_script_module("card-check.py", "card_check")
+
+
+@pytest.fixture
+def gen_ref_docs():
+    return load_script_module("generate-ref-docs.py", "generate_ref_docs")
+
+
+@pytest.fixture
+def gen_shared_types():
+    return load_script_module("generate-shared-types.py", "generate_shared_types")

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def load_script_module(filename: str, module_name: str):
+    module_path = SCRIPTS_DIR / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def gen_ref_docs():
+    return load_script_module("generate-ref-docs.py", "generate_ref_docs")
+
+
+@pytest.fixture
+def gen_shared_types():
+    return load_script_module("generate-shared-types.py", "generate_shared_types")

--- a/scripts/tests/test_card_check.py
+++ b/scripts/tests/test_card_check.py
@@ -1,0 +1,78 @@
+def test_resolve_relative_path_file_and_directory(card_check, tmp_path):
+    base_dir = tmp_path / "content" / "docs" / "listeners"
+    base_dir.mkdir(parents=True)
+
+    relative_file_dir = tmp_path / "content" / "docs" / "security"
+    relative_file_dir.mkdir(parents=True)
+    (relative_file_dir / "jwt.md").write_text("jwt", encoding="utf-8")
+
+    relative_subdir = tmp_path / "content" / "docs" / "traffic"
+    relative_subdir.mkdir(parents=True)
+    (relative_subdir / "timeout.md").write_text("timeout", encoding="utf-8")
+
+    assert card_check.resolve_relative_path(str(base_dir), "../security/jwt") == "jwt"
+    assert card_check.resolve_relative_path(str(base_dir), "../traffic") == "traffic"
+    assert card_check.resolve_relative_path(str(base_dir), "../missing/path") is None
+
+
+def test_find_cards_in_index_resolves_relative_and_external(card_check, tmp_path):
+    base_dir = tmp_path / "content" / "docs" / "listeners"
+    base_dir.mkdir(parents=True)
+
+    relative_file_dir = tmp_path / "content" / "docs" / "security"
+    relative_file_dir.mkdir(parents=True)
+    (relative_file_dir / "jwt.md").write_text("jwt", encoding="utf-8")
+
+    index_file = base_dir / "_index.md"
+    index_file.write_text(
+        '\n'.join(
+            [
+                "{{< cards >}}",
+                '  {{< card link="http" title="HTTP listener" >}}',
+                '  {{< card link="../security/jwt" title="JWT" >}}',
+                '  {{< card link="https://example.com" title="External" >}}',
+                "{{< /cards >}}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    links = card_check.find_cards_in_index(str(index_file), str(base_dir))
+    assert links == {"http", "jwt", "https://example.com"}
+
+
+def test_find_valid_links_ignores_index_and_empty_dirs(card_check, tmp_path):
+    (tmp_path / "_index.md").write_text("index", encoding="utf-8")
+    (tmp_path / "http.md").write_text("http", encoding="utf-8")
+    (tmp_path / "https.md").write_text("https", encoding="utf-8")
+    (tmp_path / "empty-dir").mkdir()
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "readme.md").write_text("nested", encoding="utf-8")
+
+    valid_links = card_check.find_valid_links(str(tmp_path))
+    assert valid_links == {"http", "https", "nested"}
+
+
+def test_check_directory_reports_missing_and_extra_cards(card_check, tmp_path, capsys):
+    (tmp_path / "good.md").write_text("good", encoding="utf-8")
+    (tmp_path / "missing.md").write_text("missing", encoding="utf-8")
+    (tmp_path / "_index.md").write_text(
+        '\n'.join(
+            [
+                "{{< cards >}}",
+                '  {{< card link="good" title="Good" >}}',
+                '  {{< card link="extra" title="Extra" >}}',
+                "{{< /cards >}}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    card_check.check_directory(str(tmp_path))
+
+    output = capsys.readouterr().out
+    assert "Missing cards" in output
+    assert "missing" in output
+    assert "Extra cards" in output
+    assert "extra" in output

--- a/scripts/tests/test_generate_ref_docs.py
+++ b/scripts/tests/test_generate_ref_docs.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+
+
+def test_is_version_2_2_or_later(gen_ref_docs):
+    assert gen_ref_docs.is_version_2_2_or_later("main") is True
+    assert gen_ref_docs.is_version_2_2_or_later("2.2.x") is True
+    assert gen_ref_docs.is_version_2_2_or_later("2.3.x") is True
+    assert gen_ref_docs.is_version_2_2_or_later("2.1.x") is False
+    assert gen_ref_docs.is_version_2_2_or_later("invalid") is False
+
+
+def test_extract_package_section(gen_ref_docs):
+    content = "\n".join(
+        [
+            "# API Reference",
+            "## Packages",
+            "- [gateway.kgateway.dev/v1alpha1](#gatewaykgatewaydevv1alpha1)",
+            "- [other.package/v1alpha1](#otherpackagev1alpha1)",
+            "",
+            "## gateway.kgateway.dev/v1alpha1",
+            "Gateway package docs",
+            "",
+            "## other.package/v1alpha1",
+            "Other package docs",
+        ]
+    )
+    extracted = gen_ref_docs.extract_package_section(content, "gateway.kgateway.dev/v1alpha1")
+    assert extracted is not None
+    assert "## Packages" in extracted
+    assert "gateway.kgateway.dev/v1alpha1" in extracted
+    assert "Gateway package docs" in extracted
+    assert "other.package/v1alpha1" not in extracted.split("## gateway.kgateway.dev/v1alpha1", 1)[1]
+
+
+def test_extract_package_section_returns_none_when_missing(gen_ref_docs):
+    content = "## Packages\n- [a](#a)\n"
+    assert gen_ref_docs.extract_package_section(content, "missing.package/v1alpha1") is None
+
+
+def test_resolve_branch_for_version(gen_ref_docs, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, capture_output, text, check):
+        calls.append(cmd)
+        return SimpleNamespace(stdout="abc refs/heads/v2.2.x")
+
+    monkeypatch.setattr(gen_ref_docs.subprocess, "run", fake_run)
+
+    assert gen_ref_docs.resolve_branch_for_version("2.2.x", "latest") == "v2.2.x"
+    assert calls, "expected ls-remote check to run for non-main versions"
+    assert gen_ref_docs.resolve_branch_for_version("2.2.x", "main") == "main"
+
+
+def test_resolve_tag_for_version_filters_rc_beta_and_returns_latest(gen_ref_docs, monkeypatch):
+    output = "\n".join(
+        [
+            "sha1 refs/tags/v2.2.1",
+            "sha2 refs/tags/v2.2.3-rc1",
+            "sha3 refs/tags/v2.2.4-beta1",
+            "sha4 refs/tags/v2.2.5",
+        ]
+    )
+
+    def fake_run(cmd, capture_output, text, check):
+        return SimpleNamespace(stdout=output)
+
+    monkeypatch.setattr(gen_ref_docs.subprocess, "run", fake_run)
+
+    resolved = gen_ref_docs.resolve_tag_for_version("2.2.x", "latest")
+    assert resolved == "v2.2.5"
+
+
+def test_generate_shared_types_invokes_script_when_shared_exists(gen_ref_docs, monkeypatch, tmp_path):
+    api_file = tmp_path / "api.md"
+    api_file.write_text("api", encoding="utf-8")
+
+    kgateway_dir = tmp_path / "kgateway"
+    shared_dir = kgateway_dir / "api" / "v1alpha1" / "shared"
+    source_dir = kgateway_dir / "api" / "v1alpha1" / "kgateway"
+    shared_dir.mkdir(parents=True)
+    source_dir.mkdir(parents=True)
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(gen_ref_docs.subprocess, "run", fake_run)
+
+    gen_ref_docs._generate_shared_types(str(api_file), kgateway_dir=str(kgateway_dir))
+
+    assert len(calls) == 1
+    assert calls[0][0:2] == ["python3", "scripts/generate-shared-types.py"]
+    assert calls[0][2] == str(shared_dir)
+    assert calls[0][3] == str(api_file)
+    assert calls[0][4] == str(source_dir)

--- a/scripts/tests/test_generate_shared_types.py
+++ b/scripts/tests/test_generate_shared_types.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+
+def test_extract_doc_comment_skips_kubebuilder_annotations(gen_shared_types):
+    lines = [
+        "// +kubebuilder:validation:Enum=HTTP1;HTTP2",
+        "// HTTP version to use.",
+        "type HTTPVersion string",
+    ]
+    assert gen_shared_types.extract_doc_comment(lines, 2) == "HTTP version to use."
+
+
+def test_extract_validation_annotations(gen_shared_types):
+    lines = [
+        "// +kubebuilder:validation:Enum=HTTP1;HTTP2",
+        "// +kubebuilder:validation:MinLength=1",
+        "type HTTPVersion string",
+    ]
+    assert gen_shared_types.extract_validation_annotations(lines, 2) == [
+        "Enum=HTTP1;HTTP2",
+        "MinLength=1",
+    ]
+
+
+def test_parse_go_file_extracts_struct_and_alias(gen_shared_types, tmp_path):
+    go_file = tmp_path / "types.go"
+    go_file.write_text(
+        "\n".join(
+            [
+                "package shared",
+                "",
+                "// AuthConfig contains auth settings.",
+                "type AuthConfig struct {",
+                '    // Issuer is the token issuer.',
+                '    Issuer string `json:"issuer"`',
+                '    // Audiences are accepted audiences.',
+                '    Audiences []string `json:"audiences,omitempty"`',
+                "}",
+                "",
+                "// ProtocolName is the protocol enum.",
+                "type ProtocolName = string",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = gen_shared_types.parse_go_file(go_file, source="shared", is_enterprise=False)
+    by_name = {type_info.name: type_info for type_info in parsed}
+
+    struct_type = by_name["AuthConfig"]
+    assert struct_type.kind == "struct"
+    assert struct_type.description == "AuthConfig contains auth settings."
+    assert len(struct_type.fields) == 2
+    assert struct_type.fields[0].json_name == "issuer"
+    assert struct_type.fields[0].required is True
+    assert struct_type.fields[1].json_name == "audiences"
+    assert struct_type.fields[1].required is False
+
+    alias_type = by_name["ProtocolName"]
+    assert alias_type.kind == "alias"
+    assert alias_type.underlying_type == "string"
+
+
+def test_format_go_type_as_link_respects_documented_types(gen_shared_types):
+    assert (
+        gen_shared_types.format_go_type_as_link("AuthConfig", {"AuthConfig"})
+        == "[AuthConfig](#authconfig)"
+    )
+    assert gen_shared_types.format_go_type_as_link("UnknownType", {"AuthConfig"}) == "_UnknownType_"
+    assert (
+        gen_shared_types.format_go_type_as_link("[]*AuthConfig", {"AuthConfig"})
+        == "[]*[AuthConfig](#authconfig)"
+    )
+
+
+def test_generate_markdown_adds_enterprise_suffix_for_duplicates(gen_shared_types):
+    oss = gen_shared_types.TypeInfo(
+        name="AuthConfig",
+        kind="struct",
+        source="shared",
+        is_enterprise=False,
+        fields=[
+            gen_shared_types.FieldInfo(
+                name="Issuer",
+                go_type="string",
+                json_name="issuer",
+                description="Issuer field.",
+                required=True,
+            )
+        ],
+    )
+    enterprise = gen_shared_types.TypeInfo(
+        name="AuthConfig",
+        kind="struct",
+        source="shared",
+        is_enterprise=True,
+        fields=[
+            gen_shared_types.FieldInfo(
+                name="Issuer",
+                go_type="string",
+                json_name="issuer",
+                description="Enterprise issuer field.",
+                required=True,
+            )
+        ],
+    )
+
+    markdown = gen_shared_types.generate_markdown(
+        [oss, enterprise],
+        referenced_types={"AuthConfig"},
+        existing_doc_types=set(),
+    )
+
+    assert "#### AuthConfig" in markdown
+    assert "#### AuthConfig (Enterprise)" in markdown
+
+
+def test_find_documented_types_and_broken_links(gen_shared_types, tmp_path):
+    doc_file = Path(tmp_path / "api.md")
+    doc_file.write_text(
+        "\n".join(
+            [
+                "#### KnownType",
+                "",
+                "Works with [KnownType](#knowntype).",
+                "Broken link to [MissingType](#missingtype).",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    documented = gen_shared_types.find_documented_types(doc_file)
+    broken = gen_shared_types.find_all_broken_links(doc_file)
+
+    assert documented == {"KnownType"}
+    assert broken == {"MissingType"}


### PR DESCRIPTION
## Description
This PR adds unit test coverage for Python scripts under `scripts/` and wires those tests into GitHub Actions.

Closes #631.

## Changes
- Add `scripts/tests/` pytest suite for:
 - `card-check.py`
 - `generate-ref-docs.py`
 - `generate-shared-types.py`
- Add `scripts/tests/conftest.py` to load script modules with hyphenated filenames
- Add workflow `.github/workflows/scripts-tests.yml` to run script unit tests in CI
- Update `scripts/README.md` with unit test instructions

## Validation
- `python3 -m pytest scripts/tests -q` (all tests passing)
- `hugo --config hugo.yaml` (successful build with CI-compatible Hugo version)
- `python3 scripts/card-check.py` (non-blocking existing warnings unchanged)