### PR TITLE
docs: add JWT claim extraction guide

### DIFF
--- a/assets/docs/pages/security/jwt-claim-extraction.md
+++ b/assets/docs/pages/security/jwt-claim-extraction.md
@@ -1,0 +1,130 @@
+After a request is successfully authenticated via JWT, you can extract specific claims from the token payload and inject them as custom HTTP request headers. These headers are then forwarded to the upstream application, allowing your backend services to access user information (such as user IDs, roles, or email addresses) without having to re-parse or validate the JWT themselves.
+
+## JWT claim extraction in kgateway
+
+The kgateway proxy supports JWT claim extraction through the `claimsToHeaders` field in a `JWTProvider` configuration. You specify the name of the claim you want to extract and the name of the header you want to map it to.
+
+If a claim is present in the validated JWT, the gateway adds the corresponding header to the request. If the claim is missing, the header is not added.
+
+The following diagram illustrates the flow:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant AGW as Kgateway Proxy
+    participant IdP as Identity Provider<br/>(JWKS)
+    participant Backend as Upstream App
+
+    C->>AGW: Request with JWT<br/>(Authorization: Bearer <token>)
+    
+    AGW->>AGW: Validate JWT signature<br/>and expiration
+    
+    Note over AGW: JWT Claim Extraction
+    AGW->>AGW: Extract "sub" -> "X-User-ID"<br/>Extract "email" -> "X-User-Email"
+    
+    AGW->>Backend: Forward request with headers<br/>X-User-ID: 123<br/>X-User-Email: user@example.com
+    
+    Backend-->>AGW: Response
+    AGW-->>C: Response
+```
+
+## Before you begin
+
+{{< reuse "docs/snippets/prereq.md" >}}
+
+## Extract claims to headers
+
+To extract claims, you configure the `claimsToHeaders` list within your JWT provider configuration.
+
+1. Create a `GatewayExtension` that defines your JWT provider. In this example, we use a provider that validates JWTs against a remote JWKS endpoint and extracts the `sub` and `email` claims.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}
+   kind: GatewayExtension
+   metadata:
+     name: jwt-provider
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   spec:
+     jwt:
+       providers:
+         - name: my-idp
+           issuer: https://auth.example.com/
+           audiences:
+             - my-app-audience
+           remoteJwks:
+             url: https://auth.example.com/.well-known/jwks.json
+           claimsToHeaders:
+             - name: "sub"
+               header: "X-User-ID"
+             - name: "email"
+               header: "X-User-Email"
+   EOF
+   ```
+
+2. Create a {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that applies the JWT authentication to your gateway.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}
+   kind: {{< reuse "docs/snippets/trafficpolicy.md" >}}
+   metadata:
+     name: jwt-auth-policy
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   spec:
+     targetRefs:
+       - group: gateway.networking.k8s.io
+         kind: Gateway
+         name: http
+     jwt:
+       extensionRef:
+         name: jwt-provider
+         namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   EOF
+   ```
+
+3. Send a request to your application with a valid JWT. Verify that the backend receives the injected headers. If you are using the `httpbin` app, you can check the `/headers` endpoint output.
+
+   ```sh
+   curl -X GET "http://localhost:8080/headers" \
+     -H "host: www.example.com" \
+     -H "Authorization: Bearer <your-valid-jwt>"
+   ```
+
+   **Example output**:
+   In the `headers` section of the response, you should see your custom headers:
+   ```json
+   {
+     "headers": {
+       ...
+       "X-User-ID": "user-12345",
+       "X-User-Email": "alice@example.com",
+       ...
+     }
+   }
+   ```
+
+## Cleanup
+
+{{< reuse "docs/snippets/cleanup.md" >}}
+
+```sh
+kubectl delete {{< reuse "docs/snippets/trafficpolicy.md" >}} jwt-auth-policy -n {{< reuse "docs/snippets/namespace.md" >}}
+kubectl delete gatewayextension jwt-provider -n {{< reuse "docs/snippets/namespace.md" >}}
+```
+
+## Advanced usage
+
+### Extracting nested claims
+
+If your JWT has nested claims (e.g., inside a `profile` object), you can use dot notation to reach them.
+
+```yaml
+claimsToHeaders:
+  - name: "profile.given_name"
+    header: "X-First-Name"
+```
+
+### Overwriting vs. Appending
+
+By default, if the client sends a header with the same name as one of your extracted claims (e.g., a malicious client sending their own `X-User-ID` header), kgateway will **overwrite** the client's header with the verified value from the JWT. This ensures that your backend can trust the value in these headers.

--- a/content/docs/envoy/latest/security/_index.md
+++ b/content/docs/envoy/latest/security/_index.md
@@ -15,6 +15,7 @@ For example, you might use HTTPS listeners for external client connections, enfo
   {{< card link="cors" title="CORS" >}}
   {{< card link="csrf" title="CSRF" >}}
   {{< card link="extauth" title="Bring your own external auth" >}}
+  {{< card link="jwt-claim-extraction" title="JWT claim extraction" >}}
   {{< card link="ratelimit" title="Rate limiting" >}}
   {{< card link="backend-tls" title="Backend TLS" >}}
   {{< card path="/setup/listeners/https/" title="HTTPS listener" icon="bookmark">}}

--- a/content/docs/envoy/latest/security/jwt-claim-extraction.md
+++ b/content/docs/envoy/latest/security/jwt-claim-extraction.md
@@ -1,0 +1,7 @@
+---
+title: JWT claim extraction
+weight: 60
+description: Extract claims from a validated JWT and inject them as request headers for upstream applications.
+---
+
+{{< reuse "docs/pages/security/jwt-claim-extraction.md" >}}

--- a/content/docs/envoy/main/security/_index.md
+++ b/content/docs/envoy/main/security/_index.md
@@ -16,6 +16,7 @@ For example, you might use HTTPS listeners for external client connections, enfo
   {{< card link="cors" title="CORS" >}}
   {{< card link="csrf" title="CSRF" >}}
   {{< card link="extauth" title="Bring your own external auth" >}}
+  {{< card link="jwt-claim-extraction" title="JWT claim extraction" >}}
   {{< card link="ratelimit" title="Rate limiting" >}}
   {{< card link="backend-tls" title="Backend TLS" >}}
   {{< card path="/setup/listeners/https/" title="HTTPS listener" icon="bookmark">}}

--- a/content/docs/envoy/main/security/jwt-claim-extraction.md
+++ b/content/docs/envoy/main/security/jwt-claim-extraction.md
@@ -1,0 +1,7 @@
+---
+title: JWT claim extraction
+weight: 60
+description: Extract claims from a validated JWT and inject them as request headers for upstream applications.
+---
+
+{{< reuse "docs/pages/security/jwt-claim-extraction.md" >}}


### PR DESCRIPTION

# Description

This PR adds a new security guide for **JWT Claim Extraction and Header Injection**.

- **Motivation:** While issue #725 covers OIDC integration and JWT validation, users need clear guidance on how to leverage validated identities for downstream services. Extracting claims (like user IDs or emails) into HTTP headers is a standard "Day 2" task for most gateway deployments.
- **What changed:**
    - Created a core technical guide in `assets/docs/pages/security/jwt-claim-extraction.md` with visual Mermaid diagrams.
    - Added versioned wrapper pages for both `envoy/latest` and `envoy/main`.
    - Updated the security index pages with a new navigation card for "JWT claim extraction".
- **Related issues:** Related to #725

# Change Type

/kind documentation

# Changelog

```release-note
Added guide for JWT claim extraction and header injection in the security documentation.
```

# Additional Notes

- The guide includes a sequence diagram to help users visualize the flow between the Proxy, IdP, and Upstream application.
- I've used existing repository shortcodes (like `{{< reuse ... >}}`) to ensure consistency with the current documentation style.
- Verified that the configuration examples match the `gateway.kgateway.dev/v1alpha1` API schema.
