### PR TITLE
docs: fix HTML syntax errors and mismatched tags in content files

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ excludeSearch: true
   <div class="py-8 lg:py-16 flex items-center px-6">
     <div class="text-center mx-auto inline-block">
       <h1 class="text-3xl/tight lg:text-6xl/tight max-w-4xl font-bold mt-6 mx-auto font-heading">The most widely deployed gateway in Kubernetes for microservices</h1>
-      <p class="text-2xl lg:text-4xl max-w-4xl font-semibold mt-6 lg:mt-16 mx-auto font-heading">Kgateway is:</h2>
+      <p class="text-2xl lg:text-4xl max-w-4xl font-semibold mt-6 lg:mt-16 mx-auto font-heading">Kgateway is:</p>
     </div>
   </div>
 

--- a/content/slack.md
+++ b/content/slack.md
@@ -19,4 +19,5 @@ excludeSearch: true
   <ul class="list-disc">
     <li>Visit <a class="text-primary-bg" href="https://slack.cncf.io/">https://slack.cncf.io/</a> and create your Slack account.</li>
     <li>Join us in the <a class="text-primary-bg" href="https://cloud-native.slack.com/archives/C080D3PJMS4">#kgateway channel</a>.</li>
+  </ul>
 </section>


### PR DESCRIPTION
### Description
This PR fixes several HTML syntax errors identified during a codebase audit. These errors could lead to broken layouts or improper rendering on the documentation site.

### Changes
- **content/_index.md**: Fixed a mismatched closing tag where a paragraph (`<p>`) was incorrectly closed with `</h2>`.
- **content/slack.md**: Added a missing `</ul>` closing tag at the end of the Slack community instructions list.

### Verification
- Verified using a custom diagnostic script that no HTML tag mismatches remain in the affected files.
- Ensured all commits are signed-off according to DCO requirements.

Fixes #741 
