### PR TITLE
build: add missing postcss-import dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,9 @@
 {
-  "name": "main",
+  "name": "kgateway.dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "main",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.10",
         "tailwindcss": "^3.3.5"
@@ -12,7 +11,8 @@
       "devDependencies": {
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.47",
-        "postcss-cli": "^11.0.0"
+        "postcss-cli": "^11.0.0",
+        "postcss-import": "^16.1.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1123,16 +1123,18 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
         "resolve": "^1.1.7"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
@@ -1600,6 +1602,23 @@
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
-    "postcss-cli": "^11.0.0"
+    "postcss-cli": "^11.0.0",
+    "postcss-import": "^16.1.1"
   }
 }


### PR DESCRIPTION
### Description
This PR adds `postcss-import` to the `devDependencies` in `package.json`.

### Rationale
The project's `assets/css/postcss.config.js` explicitly requires `postcss-import`, but the package was not listed as a direct dependency. Explicitly listing it ensures build reproducibility and prevents potential failures in clean environments or CI/CD pipelines where transitive dependencies might not be guaranteed.

### Changes
- Added `postcss-import` to `devDependencies` in `package.json`.
- Updated `package-lock.json` accordingly.

### Verification
- Verified that `postcss-import` is now correctly listed in `package.json`.
- Ensured the commit is signed-off according to DCO requirements.

Fixes : #743 