### PR TITLE
docs: fix redirect card links for custom status codes

### DIFF
--- a/content/docs/envoy/latest/traffic-management/redirect/_index.md
+++ b/content/docs/envoy/latest/traffic-management/redirect/_index.md
@@ -9,5 +9,5 @@ Redirect requests to another host or path.
   {{< card link="https" title="HTTPS redirect" >}}
   {{< card link="host" title="Host redirect" >}}
   {{< card link="path" title="Path redirect" >}}
-  {{< card link="https" title="Custom redirect status codes" >}}
+  {{< card link="custom" title="Custom redirect status codes" >}}
 {{< /cards >}}

--- a/content/docs/envoy/main/traffic-management/redirect/_index.md
+++ b/content/docs/envoy/main/traffic-management/redirect/_index.md
@@ -9,5 +9,5 @@ Redirect requests to another host or path.
   {{< card link="https" title="HTTPS redirect" >}}
   {{< card link="host" title="Host redirect" >}}
   {{< card link="path" title="Path redirect" >}}
-  {{< card link="https" title="Custom redirect status codes" >}}
+  {{< card link="custom" title="Custom redirect status codes" >}}
 {{< /cards >}}


### PR DESCRIPTION
## What changed

This PR fixes the `Custom redirect status codes` card in the redirect documentation so it points to the correct `custom` page instead of the `https` page.

## Why

Both the `latest` and `main` redirect index pages currently render a card titled `Custom redirect status codes`, but that card links to the HTTPS redirect guide instead of the dedicated custom redirect status codes guide.

## Impact

Users browsing the redirect docs in `latest` and `main` now land on the correct page for custom redirect status codes.

## Root cause

The card link in each `_index.md` file used `link="https"` instead of `link="custom"`.

## Validation

- Reviewed the diff to confirm only the two intended `_index.md` files changed
- Verified both cards now reference `custom`
- Local Hugo build not run here because `hugo` is not installed in this environment
