### PR TITLE
fix: improve card-check validation and Windows console output

### DIFF
--- a/scripts/card-check.py
+++ b/scripts/card-check.py
@@ -1,88 +1,152 @@
-import os
 import re
 import sys
+from pathlib import Path, PurePosixPath
 
-def resolve_relative_path(base_dir, relative_path):
-    """Convert a relative Hugo link (e.g., ../../traffic-management/direct-response) to an absolute path."""
-    abs_path = os.path.normpath(os.path.join(base_dir, relative_path))
-    if os.path.isdir(abs_path) and any(f.endswith(".md") for f in os.listdir(abs_path)):
-        return os.path.basename(abs_path)  # Valid directory with .md files
-    elif os.path.isfile(abs_path + ".md"):
-        return os.path.basename(abs_path)  # Valid .md file
-    return None  # Invalid link
+CARD_PATTERN = re.compile(r'{{<\s*card\s+(?:link|path)="([^"]+)"')
+HTML_COMMENT_PATTERN = re.compile(r"<!--.*?-->", re.DOTALL)
 
-def find_cards_in_index(index_file, base_dir):
-    """Extract card links from _index.md file and resolve relative paths."""
-    with open(index_file, "r", encoding="utf-8") as file:
-        content = file.read()
 
-    raw_card_links = re.findall(r'{{<\s*card\s+link="([^"]+)"', content)
-    resolved_links = set()
+def has_markdown_content(path):
+    """Return True when the directory contains markdown content."""
+    return path.is_dir() and any(child.suffix == ".md" for child in path.iterdir())
 
-    for link in raw_card_links:
-        if link.startswith(("http", "https")):
-            resolved_links.add(link)  # Allow external links
-        elif link.startswith("../") or link.startswith("./") or link.startswith("/"):
-            resolved = resolve_relative_path(base_dir, link)
-            if resolved:
-                resolved_links.add(resolved)  # Add valid resolved relative paths
-        else:
-            resolved_links.add(link)  # Add normal local links
 
-    return resolved_links
+def get_docs_root():
+    return (Path(__file__).resolve().parent / "../content/docs").resolve()
+
+
+def get_section_root(base_dir, docs_root):
+    """Resolve the versioned docs root used by absolute `path=` cards."""
+    try:
+        relative_parts = base_dir.resolve().relative_to(docs_root).parts
+    except ValueError:
+        return docs_root
+
+    if len(relative_parts) >= 2:
+        return docs_root.joinpath(*relative_parts[:2])
+    return docs_root
+
+
+def normalize_doc_target(candidate):
+    """Resolve a candidate path to either an existing markdown file or docs directory."""
+    if candidate.is_file():
+        return candidate
+    if has_markdown_content(candidate):
+        return candidate
+
+    markdown_candidate = candidate.with_suffix(".md")
+    if markdown_candidate.is_file():
+        return markdown_candidate
+
+    return None
+
+
+def resolve_card_target(base_dir, docs_root, target):
+    """Resolve link/path card values to a docs file or directory when possible."""
+    if target.startswith(("http://", "https://")):
+        return None
+
+    posix_target = PurePosixPath(target)
+    if target.startswith("/docs/"):
+        candidate = docs_root.joinpath(*posix_target.parts[2:])
+    elif target.startswith("/"):
+        candidate = get_section_root(base_dir, docs_root).joinpath(*posix_target.parts[1:])
+    else:
+        candidate = base_dir.joinpath(*posix_target.parts)
+
+    return normalize_doc_target(candidate.resolve())
+
+
+def extract_card_targets(index_file):
+    """Extract link/path values from card shortcodes and ignore HTML comments."""
+    content = index_file.read_text(encoding="utf-8")
+    uncommented = HTML_COMMENT_PATTERN.sub("", content)
+    return set(CARD_PATTERN.findall(uncommented))
+
 
 def find_valid_links(directory):
-    """Find all valid links (either .md files or subdirectories that contain at least one .md file)."""
+    """Find the direct child links that should appear in local cards."""
     valid_links = set()
 
-    for item in os.listdir(directory):
-        item_path = os.path.join(directory, item)
-
-        # If it's a markdown file (excluding _index.md), add it as a valid link
-        if item.endswith(".md") and item != "_index.md":
-            valid_links.add(os.path.splitext(item)[0])
-
-        # If it's a directory, check if it contains at least one .md file
-        elif os.path.isdir(item_path):
-            md_files = [f for f in os.listdir(item_path) if f.endswith(".md")]
-            if md_files:  # Only include subdirectories with .md files
-                valid_links.add(item)
+    for item in directory.iterdir():
+        if item.is_file() and item.suffix == ".md" and item.name != "_index.md":
+            valid_links.add(item.stem)
+        elif has_markdown_content(item):
+            valid_links.add(item.name)
 
     return valid_links
 
-def check_directory(directory):
-    """Check for missing or extra cards in _index.md."""
-    index_file = os.path.join(directory, "_index.md")
 
-    if not os.path.exists(index_file):
+def map_to_local_link(base_dir, resolved_target, valid_links):
+    """Map a resolved target back to a local child card when it points into this subtree."""
+    try:
+        relative_path = resolved_target.relative_to(base_dir)
+    except ValueError:
+        return None
+
+    if len(relative_path.parts) == 1 and resolved_target.is_file():
+        candidate = resolved_target.stem
+        return candidate if candidate in valid_links else None
+
+    candidate = relative_path.parts[0]
+    return candidate if candidate in valid_links else None
+
+
+def check_directory(directory, docs_root):
+    """Check for missing or extra cards in _index.md."""
+    index_file = directory / "_index.md"
+
+    if not index_file.exists():
         print(f"Skipping {directory}: No _index.md file.")
         return
 
-    card_links = find_cards_in_index(index_file, directory)
+    card_targets = extract_card_targets(index_file)
     valid_links = find_valid_links(directory)
+    matched_local_links = set()
+    extra_cards = set()
 
-    # Allow external links (http, https)
-    extra_cards = {card for card in card_links if card not in valid_links and not card.startswith(("http", "https"))}
-    missing_cards = valid_links - card_links
+    for target in card_targets:
+        if target.startswith(("http://", "https://")):
+            continue
+
+        if target in valid_links:
+            matched_local_links.add(target)
+            continue
+
+        resolved_target = resolve_card_target(directory, docs_root, target)
+        if not resolved_target:
+            extra_cards.add(target)
+            continue
+
+        local_match = map_to_local_link(directory, resolved_target, valid_links)
+        if local_match:
+            matched_local_links.add(local_match)
+
+    missing_cards = valid_links - matched_local_links
 
     if missing_cards:
-        print(f"⚠️ Missing cards in {index_file}: {missing_cards}")
+        print(f"[WARN] Missing cards in {index_file}: {missing_cards}")
 
     if extra_cards:
-        print(f"❌ Extra cards in {index_file} that don’t match any local .md file, valid subdirectory, or valid relative path: {extra_cards}")
+        print(
+            "[ERROR] Extra cards in "
+            f"{index_file} that don't match any local .md file, valid subdirectory, or valid relative path: {extra_cards}"
+        )
+
 
 def main():
     """Run checks for a specific directory or default to 'content/docs'."""
     if len(sys.argv) > 1:
-        content_root = os.path.abspath(sys.argv[1])
+        content_root = Path(sys.argv[1]).resolve()
     else:
-        content_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../content/docs"))
+        content_root = get_docs_root()
 
-    print(f"Checking directories under: {content_root}")  # Debugging
+    print(f"Checking directories under: {content_root}")
 
-    for root, dirs, files in os.walk(content_root):
+    for root, _, files in content_root.walk():
         if "_index.md" in files:
-            check_directory(root)
+            check_directory(root, content_root)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

This updates `scripts/card-check.py` so it correctly handles card patterns that already exist in the docs tree and no longer crashes on Windows consoles with a non-UTF-8 stdout encoding.

## Root cause

The previous validator had three separate issues:

- it only parsed `{{< card link="..." >}}` and ignored valid `{{< card path="..." >}}` entries
- it only validated direct child pages/directories, which produced false positives for valid nested, cross-folder, and site-absolute docs links%0