### PR TITLE
docs: fix Envoy version selector and 2.1.x Agentgateway link

### DIFF
--- a/content/docs/envoy/2.1.x/integrations/_index.md
+++ b/content/docs/envoy/2.1.x/integrations/_index.md
@@ -7,7 +7,7 @@ description: Integrate kgateway with common cloud-native tools.
 Integrate kgateway with common cloud-native tools.
 
 {{< cards >}}
-  {{< card link="../../../ai/" title="Agentgateway" >}}
+  {{< card link="../ai/" title="Agentgateway" >}}
   {{< card link="argo" title="Argo Rollouts" >}}
   {{< card link="aws-elb" title="AWS ELBs" >}}
   {{< card link="external-dns-cert-manager" title="ExternalDNS & Cert Manager"  >}}

--- a/content/docs/envoy/_index.md
+++ b/content/docs/envoy/_index.md
@@ -14,5 +14,4 @@ Select the version for the kgateway docs.
   {{< card link="/docs/envoy/main/" title="2.3 (main)" subtitle="Latest development version" >}}
   {{< card link="/docs/envoy/latest/" title="2.2 (latest)" subtitle="Current stable release" >}}
   {{< card link="/docs/envoy/2.1.x/" title="2.1" subtitle="Previous stable release" >}}
-  {{< card link="/docs/envoy/2.0.x/" title="2.0" subtitle="Earlier stable release" >}}
 {{< /cards >}}

--- a/content/docs/envoy/_index.md
+++ b/content/docs/envoy/_index.md
@@ -11,7 +11,8 @@ description:
 Select the version for the kgateway docs.
 
 {{< cards >}}
-  {{< card link="/docs/envoy/main/" title="2.2 (main)" subtitle="Latest development version" >}}
-  {{< card link="/docs/envoy/latest/" title="2.1 (latest)" subtitle="Current stable release" >}}
-  {{< card link="/docs/envoy/2.0.x/" title="2.0" subtitle="Previous stable release" >}}
+  {{< card link="/docs/envoy/main/" title="2.3 (main)" subtitle="Latest development version" >}}
+  {{< card link="/docs/envoy/latest/" title="2.2 (latest)" subtitle="Current stable release" >}}
+  {{< card link="/docs/envoy/2.1.x/" title="2.1" subtitle="Previous stable release" >}}
+  {{< card link="/docs/envoy/2.0.x/" title="2.0" subtitle="Earlier stable release" >}}
 {{< /cards >}}


### PR DESCRIPTION
## Summary

This fixes two docs navigation issues in the Envoy docs:

- update the `/docs/envoy/` version selector so