### PR TITLE
Added secret response and request headers

### DIFF
--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -536,7 +536,7 @@ curl -vi localhost:8080/headers -H "host: headers.example"
 {{< version include-if="2.3.x" >}}
 ## Source a header value from a Secret {#header-from-secret}
 
-If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
+If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text or send it as part of the request. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` in the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource. The gateway proxy resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, the proxy applies the changes automatically.
 
 {{< callout type="info" >}}
 This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" >}}. The Gateway API `HTTPRoute` `RequestHeaderModifier` filter does not support `secretRef`.

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -533,6 +533,172 @@ curl -vi localhost:8080/headers -H "host: headers.example"
    {{% /tab %}}
    {{< /tabs >}}
 
+{{% version include-if="2.3.x" %}}
+## Use a value from a Secret {#header-from-secret}
+
+If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
+
+{{< callout type="info" >}}
+This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" >}}. The Gateway API `HTTPRoute` `RequestHeaderModifier` filter does not support `secretRef`.
+{{< /callout >}}
+
+1. Create a Secret that holds the values you want to inject. The data keys do not need to match the eventual header names.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: backend-creds
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   type: Opaque
+   stringData:
+     api-key: my-secret-api-key
+     tenant-id: tenant-abc
+   EOF
+   ```
+
+2. Create an HTTPRoute for the httpbin app. The example selects the http Gateway that you created before you began.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: HTTPRoute
+   metadata:
+     name: httpbin-headers
+     namespace: httpbin
+   spec:
+     parentRefs:
+     - name: http
+       namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     hostnames:
+       - headers.example
+     rules:
+       - backendRefs:
+           - name: httpbin
+             port: 8000
+   EOF
+   ```
+
+3. Create a {{< reuse "docs/snippets/trafficpolicy.md" >}} that sets two request headers from the `backend-creds` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}
+   kind: {{< reuse "docs/snippets/trafficpolicy.md" >}}
+   metadata:
+     name: httpbin-secret-headers
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   spec:
+     targetRefs:
+     - group: gateway.networking.k8s.io
+       kind: Gateway
+       name: http
+     headerModifiers:
+       request:
+         set:
+         - name: X-Api-Key
+           secretRef:
+             name: backend-creds
+             key: api-key
+         - name: X-Tenant-Id
+           secretRef:
+             name: backend-creds
+             key: tenant-id
+   EOF
+   ```
+
+   The {{< reuse "docs/snippets/trafficpolicy.md" >}} `targetRefs` field does not accept a `namespace`. The policy must live in the same namespace as the resource it targets. To scope this example to a single HTTPRoute instead of the whole Gateway, change `kind` to `HTTPRoute` and `name` to the route's name, and create the {{< reuse "docs/snippets/trafficpolicy.md" >}} (and the Secret) in the route's namespace.
+
+   |Setting|Description|
+   |--|--|
+   |`headerModifiers.request.set.name`|The HTTP header name that the upstream service receives. |
+   |`headerModifiers.request.set.secretRef.name`|The name of the Kubernetes Secret to read the value from. If the Secret does not exist when the policy is applied, the policy reports `Accepted=False` and the affected route returns a 500 response. |
+   |`headerModifiers.request.set.secretRef.key`|The key in the Secret's `data` to use as the header value. Optional. If `key` is omitted, it defaults to the value of `headerModifiers.request.set.name`. |
+   |`headerModifiers.request.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. To reference a Secret in a different namespace, see [Cross-namespace Secrets](#cross-namespace-secrets). |
+
+4. Send a request to the httpbin app on the `headers.example` domain and confirm that the upstream sees the `X-Api-Key` and `X-Tenant-Id` headers with the values from the Secret. Note that the values do not appear in the {{< reuse "docs/snippets/trafficpolicy.md" >}} or in the request you sent.
+   {{< tabs items="Cloud Provider LoadBalancer,Port-forward for local testing" tabTotal="2" >}}
+   {{% tab tabName="Cloud Provider LoadBalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/headers -H "host: headers.example:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/headers -H "host: headers.example"
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+
+   Example output:
+   ```json
+   {
+     "headers": {
+       "Host": [
+         "headers.example:8080"
+       ],
+       "X-Api-Key": [
+         "my-secret-api-key"
+       ],
+       "X-Tenant-Id": [
+         "tenant-abc"
+       ],
+       ...
+     }
+   }
+   ```
+
+5. Optional: When you are finished, you can clean up the resources that you created.
+
+```sh
+kubectl delete httproute httpbin-headers -n httpbin
+kubectl delete {{< reuse "docs/snippets/trafficpolicy.md" >}} httpbin-secret-headers -n {{< reuse "docs/snippets/namespace.md" >}}
+kubectl delete secret backend-creds -n {{% reuse "docs/snippets/namespace.md" %}}
+```
+
+### Field defaulting
+
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. The following table shows how kgateway resolves each combination.
+
+|`name` (header)|`secretRef.key`|Behavior|
+|--|--|--|
+|`X-Api-Key`|`api-key`|The `X-Api-Key` header is set to the value of the `api-key` data key in the Secret.|
+|`X-Api-Key`|*(omitted)*|The `X-Api-Key` header is set to the value of the `X-Api-Key` data key in the Secret.|
+|*(omitted)*|`X-Api-Key`|The `X-Api-Key` header is set to the value of the `X-Api-Key` data key in the Secret.|
+|*(omitted)*|*(omitted)*|Every entry in the Secret is injected as a request header. Each data key is reused as the header name.|
+
+For example, to mirror every entry in the Secret as a request header without listing them individually:
+
+```yaml
+headerModifiers:
+  request:
+    set:
+    - secretRef:
+        name: backend-creds
+```
+
+### Cross-namespace Secrets {#cross-namespace-secrets}
+
+To reference a Secret in a different namespace from the {{< reuse "docs/snippets/trafficpolicy.md" >}}, set `secretRef.namespace` to the Secret's namespace and create a `ReferenceGrant` in that namespace. This grant allows the {{< reuse "docs/snippets/trafficpolicy.md" >}} namespace to read Secrets in the target namespace.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-secret-access
+  namespace: backend-secrets
+spec:
+  from:
+  - group: gateway.kgateway.dev
+    kind: TrafficPolicy
+    namespace: {{< reuse "docs/snippets/namespace.md" >}}
+  to:
+  - group: ""
+    kind: Secret
+```
+
+Without a matching `ReferenceGrant`, the policy reports `Accepted=False` and the affected route returns a 500 response. The same status is reported if the referenced Secret does not exist.
+
+{{% /version %}}
+
 ## Dynamic request headers {#dynamic-request-header}
 
 You can return dynamic information about the request in the request header. For more information, see the Envoy docs for [Custom request/response headers](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#custom-request-response-headers).

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -578,7 +578,7 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
    EOF
    ```
 
-3. Create a {{< reuse "docs/snippets/trafficpolicy.md" >}} that sets two request headers from the `backend-creds` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
+3. Create the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that sets two request headers values from keys that you stored in the `backend-creds` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
    ```yaml
    kubectl apply -f- <<EOF
    apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -656,16 +656,51 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. The following table shows how kgateway resolves each combination.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide.
 
-|`name` (header)|`secretRef.key`|Behavior|
-|--|--|--|
-|`X-Api-Key`|`api-key`|The `X-Api-Key` header is set to the value of the `api-key` data key in the Secret.|
-|`X-Api-Key`|*(omitted)*|The `X-Api-Key` header is set to the value of the `X-Api-Key` data key in the Secret.|
-|*(omitted)*|`X-Api-Key`|The `X-Api-Key` header is set to the value of the `X-Api-Key` data key in the Secret.|
-|*(omitted)*|*(omitted)*|Every entry in the Secret is injected as a request header. Each data key is reused as the header name.|
+#### `name` and `secretRef.key` both set
 
-For example, to mirror every entry in the Secret as a request header without listing them individually:
+kgateway sets the `name` header to the value of the `secretRef.key` data key in the Secret.
+
+```yaml
+headerModifiers:
+  request:
+    set:
+    - name: X-Api-Key
+      secretRef:
+        name: backend-creds
+        key: api-key
+```
+
+#### `secretRef.key` omitted
+
+kgateway sets the `name` header to the value of the Secret data key that matches `name`.
+
+```yaml
+headerModifiers:
+  request:
+    set:
+    - name: X-Api-Key
+      secretRef:
+        name: backend-creds
+```
+
+#### `name` omitted
+
+kgateway sets a header named after `secretRef.key` to the value of that data key in the Secret.
+
+```yaml
+headerModifiers:
+  request:
+    set:
+    - secretRef:
+        name: backend-creds
+        key: api-key
+```
+
+#### Both `name` and `secretRef.key` omitted
+
+kgateway injects every entry in the Secret as a request header. Each data key becomes a header name.
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -539,7 +539,7 @@ curl -vi localhost:8080/headers -H "host: headers.example"
 If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text or send it as part of the request. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` in the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource. The gateway proxy resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, the proxy applies the changes automatically.
 
 {{< callout type="info" >}}
-This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" >}}. The Gateway API `HTTPRoute` `RequestHeaderModifier` filter does not support `secretRef`.
+This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource. The Gateway API `HTTPRoute` `RequestHeaderModifier` filter does not support the `secretRef` option.
 {{< /callout >}}
 
 1. Create a Secret that holds the values you want to inject. The data keys do not need to match the eventual header names.

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -615,43 +615,44 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
    |`headerModifiers.request.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. To reference a Secret in a different namespace, see [Cross-namespace Secrets](#cross-namespace-secrets). |
 
 4. Send a request to the httpbin app on the `headers.example` domain and confirm that the upstream sees the `X-Api-Key` and `X-Tenant-Id` headers with the values from the Secret. Note that the values do not appear in the {{< reuse "docs/snippets/trafficpolicy.md" >}} or in the request you sent.
-   {{< tabs items="Cloud Provider LoadBalancer,Port-forward for local testing" tabTotal="2" >}}
-   {{% tab tabName="Cloud Provider LoadBalancer" %}}
-   ```sh
-   curl -vi http://$INGRESS_GW_ADDRESS:8080/headers -H "host: headers.example:8080"
-   ```
-   {{% /tab %}}
-   {{% tab tabName="Port-forward for local testing" %}}
-   ```sh
-   curl -vi localhost:8080/headers -H "host: headers.example"
-   ```
-   {{% /tab %}}
-   {{< /tabs >}}
 
-   Example output:
-   ```json
-   {
-     "headers": {
-       "Host": [
-         "headers.example:8080"
-       ],
-       "X-Api-Key": [
-         "my-secret-api-key"
-       ],
-       "X-Tenant-Id": [
-         "tenant-abc"
-       ],
-       ...
-     }
-   }
-   ```
+{{< tabs items="Cloud Provider LoadBalancer,Port-forward for local testing" tabTotal="2" >}}
+{{% tab tabName="Cloud Provider LoadBalancer" %}}
+```sh
+curl -vi http://$INGRESS_GW_ADDRESS:8080/headers -H "host: headers.example:8080"
+```
+{{% /tab %}}
+{{% tab tabName="Port-forward for local testing" %}}
+```sh
+curl -vi localhost:8080/headers -H "host: headers.example"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Example output:
+```json
+{
+  "headers": {
+    "Host": [
+      "headers.example:8080"
+    ],
+    "X-Api-Key": [
+      "my-secret-api-key"
+    ],
+    "X-Tenant-Id": [
+      "tenant-abc"
+    ],
+    ...
+  }
+}
+```
 
 5. Optional: When you are finished, you can clean up the resources that you created.
 
 ```sh
 kubectl delete httproute httpbin-headers -n httpbin
 kubectl delete {{< reuse "docs/snippets/trafficpolicy.md" >}} httpbin-secret-headers -n {{< reuse "docs/snippets/namespace.md" >}}
-kubectl delete secret backend-creds -n {{% reuse "docs/snippets/namespace.md" %}}
+kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}}
 ```
 
 ### Field defaulting

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -534,7 +534,7 @@ curl -vi localhost:8080/headers -H "host: headers.example"
    {{< /tabs >}}
 
 {{< version include-if="2.3.x" >}}
-## Use a value from a Secret {#header-from-secret}
+## Source a header value from a Secret {#header-from-secret}
 
 If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -700,7 +700,7 @@ headerModifiers:
 
 #### Both `name` and `secretRef.key` omitted
 
-kgateway injects every entry in the Secret as a request header. Each data key becomes a header name.
+kgateway injects every entry in the Secret as a request header. Each data key becomes a header name. Use this combination to mirror an entire Secret into headers without listing each entry individually.
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -605,7 +605,6 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
    EOF
    ```
 
-   The {{< reuse "docs/snippets/trafficpolicy.md" >}} `targetRefs` field does not accept a `namespace`. The policy must live in the same namespace as the resource it targets. To scope this example to a single HTTPRoute instead of the whole Gateway, change `kind` to `HTTPRoute` and `name` to the route's name, and create the {{< reuse "docs/snippets/trafficpolicy.md" >}} (and the Secret) in the route's namespace.
 
    |Setting|Description|
    |--|--|

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -611,7 +611,7 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
    |`headerModifiers.request.set.name`|The HTTP header name that the upstream service receives. |
    |`headerModifiers.request.set.secretRef.name`|The name of the Kubernetes Secret to read the value from. If the Secret does not exist when the policy is applied, the policy reports `Accepted=False` and the affected route returns a 500 response. |
    |`headerModifiers.request.set.secretRef.key`|The key in the Secret's `data` to use as the header value. Optional. If `key` is omitted, it defaults to the value of `headerModifiers.request.set.name`. |
-   |`headerModifiers.request.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. To reference a Secret in a different namespace, see [Cross-namespace Secrets](#cross-namespace-secrets). |
+   |`headerModifiers.request.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}.|
 
 4. Send a request to the httpbin app on the `headers.example` domain and confirm that the upstream sees the `X-Api-Key` and `X-Tenant-Id` headers with the values from the Secret. Note that the values do not appear in the {{< reuse "docs/snippets/trafficpolicy.md" >}} or in the request you sent.
 
@@ -674,28 +674,6 @@ headerModifiers:
     - secretRef:
         name: backend-creds
 ```
-
-### Cross-namespace Secrets {#cross-namespace-secrets}
-
-To reference a Secret in a different namespace from the {{< reuse "docs/snippets/trafficpolicy.md" >}}, set `secretRef.namespace` to the Secret's namespace and create a `ReferenceGrant` in that namespace. This grant allows the {{< reuse "docs/snippets/trafficpolicy.md" >}} namespace to read Secrets in the target namespace.
-
-```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: ReferenceGrant
-metadata:
-  name: allow-secret-access
-  namespace: backend-secrets
-spec:
-  from:
-  - group: gateway.kgateway.dev
-    kind: TrafficPolicy
-    namespace: {{< reuse "docs/snippets/namespace.md" >}}
-  to:
-  - group: ""
-    kind: Secret
-```
-
-Without a matching `ReferenceGrant`, the policy reports `Accepted=False` and the affected route returns a 500 response. The same status is reported if the referenced Secret does not exist.
 
 {{< /version >}}
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -533,7 +533,7 @@ curl -vi localhost:8080/headers -H "host: headers.example"
    {{% /tab %}}
    {{< /tabs >}}
 
-{{% version include-if="2.3.x" %}}
+{{< version include-if="2.3.x" >}}
 ## Use a value from a Secret {#header-from-secret}
 
 If the header value is sensitive, such as a backend API key or a tenant credential, you might not want to commit it to a manifest in plain text. You can source a request header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
@@ -697,7 +697,7 @@ spec:
 
 Without a matching `ReferenceGrant`, the policy reports `Accepted=False` and the affected route returns a 500 response. The same status is reported if the referenced Secret does not exist.
 
-{{% /version %}}
+{{< /version >}}
 
 ## Dynamic request headers {#dynamic-request-header}
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -658,7 +658,7 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide.
 
-#### `name` and `secretRef.key` both set
+#### Header `name` and `secretRef.key` both set
 
 kgateway sets the `name` header to the value of the `secretRef.key` data key in the Secret.
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -656,7 +656,7 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide. If the gateway proxy looks up a key that does not exist in the Secret, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### Header `name` and `secretRef.key` both set
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -700,7 +700,7 @@ headerModifiers:
 
 #### Both `name` and `secretRef.key` omitted
 
-kgateway injects every entry in the Secret as a request header. Each data key becomes a header name. Use this combination to mirror an entire Secret into headers without listing each entry individually.
+The following example omits both the header name and the data key in the secret. In such cases, the gateway proxy injects every data key entry in the Secret as a request header. Each data key becomes a header name. Use this combination to mirror an entire Secret into headers without listing each entry individually.
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -656,11 +656,11 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide. If the Secret does not contain the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional. How the gateway proxy resolves a header value depends on which combination of fields you provide. If the Secret does not contain the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### Header `name` and `secretRef.key` both set
 
-The following example defines both a name for the header (`request.set.name`) and a data key from your Secret (`secretRef.key`). The gateway proxy uses both to construct the resulting request header. In this example, the resulting request header is `X-Api-Key=api-key`. 
+The following example defines both a name for the header (`request.set.name`) and a data key from your Secret (`secretRef.key`). The gateway proxy uses `name` as the header name and looks up the header value from the Secret using `secretRef.key` as the data key.
 
 ```yaml
 headerModifiers:
@@ -687,7 +687,7 @@ headerModifiers:
 
 #### Header `name` omitted
 
-In this example, the name of the header is omitted, but a data key is referenced in the `secretRef` block. The gateway proxy looks up the data key from the Secret and injects it into a header with the same name as the data key. In the following example, the resulting request header is `api-key: api-key`. 
+In this example, the name of the header is omitted, but a data key is referenced in the `secretRef` block. The gateway proxy looks up the data key from the Secret and injects it into a header with the same name as the data key.
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -674,7 +674,7 @@ headerModifiers:
 
 #### `secretRef.key` omitted
 
-kgateway sets the `name` header to the value of the Secret data key that matches `name`.
+In this example, the data key is omitted from the `secretRef` block. The gateway proxy uses the header name (`X-Api-Key`) to look up a data key in the referenced Secret that matches the header name. Then, it uses the header name and matched data value from the Secret to construct the request header. 
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -656,7 +656,7 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide.
 
 #### Header `name` and `secretRef.key` both set
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -656,7 +656,7 @@ kubectl delete secret backend-creds -n {{< reuse "docs/snippets/namespace.md" >}
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide. If the gateway proxy looks up a key that does not exist in the Secret, the policy reports `Accepted=False` and the affected route returns a 500 response.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How the gateway proxy resolves a header value depends on which combination of fields you provide. If the Secret does not contain the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### Header `name` and `secretRef.key` both set
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -660,7 +660,7 @@ The `name` field on a `set` or `add` entry and the `key` field on `secretRef` ar
 
 #### Header `name` and `secretRef.key` both set
 
-kgateway sets the `name` header to the value of the `secretRef.key` data key in the Secret.
+The following example defines both a name for the header (`request.set.name`) and a data key from your Secret (`secretRef.key`). The gateway proxy uses both to construct the resulting request header. In this example, the resulting request header is `X-Api-Key=api-key`. 
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -687,7 +687,7 @@ headerModifiers:
 
 #### `name` omitted
 
-kgateway sets a header named after `secretRef.key` to the value of that data key in the Secret.
+In this example, the name of the header is omitted, but a data key is referenced in the `secretRef` block. The gateway proxy looks up the data key from the Secret and injects it into a header with the same name as the data key. In the following example, the resulting request header is `api-key: api-key`. 
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -685,7 +685,7 @@ headerModifiers:
         name: backend-creds
 ```
 
-#### `name` omitted
+#### Header `name` omitted
 
 In this example, the name of the header is omitted, but a data key is referenced in the `secretRef` block. The gateway proxy looks up the data key from the Secret and injects it into a header with the same name as the data key. In the following example, the resulting request header is `api-key: api-key`. 
 

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -578,7 +578,7 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
    EOF
    ```
 
-3. Create the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that sets two request headers values from keys that you stored in the `backend-creds` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
+3. Create the {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that sets two request header values from keys that you stored in the `backend-creds` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
    ```yaml
    kubectl apply -f- <<EOF
    apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}

--- a/assets/docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/docs/pages/traffic-management/header-control/request-header.md
@@ -698,7 +698,7 @@ headerModifiers:
         key: api-key
 ```
 
-#### Both `name` and `secretRef.key` omitted
+#### Header `name` and `secretRef.key` omitted
 
 The following example omits both the header name and the data key in the secret. In such cases, the gateway proxy injects every data key entry in the Secret as a request header. Each data key becomes a header name. Use this combination to mirror an entire Secret into headers without listing each entry individually.
 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -440,7 +440,7 @@ You can remove HTTP headers from a response before the response is sent back to 
    {{< /tabs >}}
 
 {{< version include-if="2.3.x" >}}
-## Use a value from a Secret {#header-from-secret}
+## Source a header value from a Secret {#header-from-secret}
 
 If a response header value is sensitive, such as an audit signing key or a service-to-service token destined for a trusted client, you might not want to commit it to a manifest in plain text. You can source a response header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -94,16 +94,16 @@ Add headers to incoming requests before they are sent back to the client. If the
    
 2. Send a request to the httpbin app on the `headers.example` domain. Verify that you get back a 200 HTTP response code and that you see the `my-response` header in the response. 
    {{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
-{{% tab tabName="Cloud Provider Loadbalancer" %}}
-```sh
-curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
-```
-{{% /tab %}}
-{{% tab tabName="Port-forward for local testing" %}}
-```sh
-curl -vi localhost:8080/response-headers -H "host: headers.example"
-```
-{{% /tab %}}
+   {{% tab tabName="Cloud Provider Loadbalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/response-headers -H "host: headers.example"
+   ```
+   {{% /tab %}}
    {{< /tabs >}}
 
    Example output: 
@@ -280,16 +280,16 @@ You can remove HTTP headers from a response before the response is sent back to 
 
 1. Send a request to the httpbin app and find the `content-length` header. 
    {{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
-{{% tab tabName="Cloud Provider Loadbalancer" %}}
-```sh
-curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: www.example.com:8080"
-```
-{{% /tab %}}
-{{% tab tabName="Port-forward for local testing" %}}
-```sh
-curl -vi localhost:8080/response-headers -H "host: www.example.com"
-```
-{{% /tab %}}
+   {{% tab tabName="Cloud Provider Loadbalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: www.example.com:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/response-headers -H "host: www.example.com"
+   ```
+   {{% /tab %}}
    {{< /tabs >}}
 
    Example output: 
@@ -393,16 +393,16 @@ curl -vi localhost:8080/response-headers -H "host: www.example.com"
 
 3. Send a request to the httpbin app on the `headers.example` domain . Verify that the `content-length` response header is removed. 
    {{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
-{{% tab tabName="Cloud Provider Loadbalancer" %}}
-```sh
-curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
-```
-{{% /tab %}}
-{{% tab tabName="Port-forward for local testing" %}}
-```sh
-curl -vi localhost:8080/response-headers -H "host: headers.example"
-```
-{{% /tab %}}
+   {{% tab tabName="Cloud Provider Loadbalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/response-headers -H "host: headers.example"
+   ```
+   {{% /tab %}}
    {{< /tabs >}}
 
    Example output: 
@@ -518,29 +518,30 @@ The same defaulting rules and cross-namespace `ReferenceGrant` requirement that 
    |`headerModifiers.response.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. Cross-namespace references require a `ReferenceGrant`. For details, see the request-header [Cross-namespace Secrets]({{< link-hextra path="/traffic-management/header-control/request-header/#cross-namespace-secrets" >}}) section. |
 
 4. Send a request to the httpbin app on the `headers.example` domain and confirm that the response includes the `X-Response-Signature` header with the value from the Secret.
-   {{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
-   {{% tab tabName="Cloud Provider Loadbalancer" %}}
-   ```sh
-   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
-   ```
-   {{% /tab %}}
-   {{% tab tabName="Port-forward for local testing" %}}
-   ```sh
-   curl -vi localhost:8080/response-headers -H "host: headers.example"
-   ```
-   {{% /tab %}}
-   {{< /tabs >}}
 
-   Example output:
-   ```sh
-   HTTP/1.1 200 OK
-   access-control-allow-credentials: true
-   access-control-allow-origin: *
-   content-type: application/json; encoding=utf-8
-   x-envoy-upstream-service-time: 0
-   x-response-signature: my-response-signing-key
-   server: envoy
-   ```
+{{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
+{{% tab tabName="Cloud Provider Loadbalancer" %}}
+```sh
+curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
+```
+{{% /tab %}}
+{{% tab tabName="Port-forward for local testing" %}}
+```sh
+curl -vi localhost:8080/response-headers -H "host: headers.example"
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Example output:
+```sh
+HTTP/1.1 200 OK
+access-control-allow-credentials: true
+access-control-allow-origin: *
+content-type: application/json; encoding=utf-8
+x-envoy-upstream-service-time: 0
+x-response-signature: my-response-signing-key
+server: envoy
+```
 
 When you are finished, optionally clean up the resources that you created.
 
@@ -645,16 +646,16 @@ You can return dynamic information about the response in the response header. Fo
 
 2. Send a request to the httpbin app on the `headers.example` domain. Verify that the `x-response-code` response header is set to the HTTP response code. 
    {{< tabs items="Cloud Provider LoadBalancer,Port-forward for local testing" tabTotal="2" >}}
-{{% tab tabName="Cloud Provider LoadBalancer" %}}
-```sh
-curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
-```
-{{% /tab %}}
-{{% tab tabName="Port-forward for local testing" %}}
-```sh
-curl -vi localhost:8080/response-headers -H "host: headers.example"
-```
-{{% /tab %}}
+   {{% tab tabName="Cloud Provider LoadBalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/response-headers -H "host: headers.example"
+   ```
+   {{% /tab %}}
    {{< /tabs >}}
 
    Example output: 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -543,7 +543,7 @@ x-response-signature: my-response-signing-key
 server: envoy
 ```
 
-When you are finished, optionally clean up the resources that you created.
+5. Optional: When you are finished, clean up the resources that you created.
 
 ```sh
 kubectl delete httproute httpbin-headers -n httpbin

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -597,7 +597,7 @@ headerModifiers:
 
 #### Both `name` and `secretRef.key` omitted
 
-kgateway injects every entry in the Secret as a response header. Each data key becomes a header name.
+kgateway injects every entry in the Secret as a response header. Each data key becomes a header name. Use this combination to mirror an entire Secret into headers without listing each entry individually.
 
 ```yaml
 headerModifiers:

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -450,7 +450,7 @@ This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" 
 
 The same defaulting rules and cross-namespace `ReferenceGrant` requirement that apply to [request headers from a Secret]({{< link-hextra path="/traffic-management/header-control/request-header/#header-from-secret" >}}) also apply here. The following example shows the basic flow for responses.
 
-1. Create a Secret that holds the value you want to inject.
+1. Create a Secret that holds the value you want to inject. The data keys do not need to match the eventual header names.
    ```yaml
    kubectl apply -f- <<EOF
    apiVersion: v1
@@ -549,6 +549,62 @@ server: envoy
 kubectl delete httproute httpbin-headers -n httpbin
 kubectl delete {{< reuse "docs/snippets/trafficpolicy.md" >}} httpbin-secret-response-headers -n {{< reuse "docs/snippets/namespace.md" >}}
 kubectl delete secret response-signing -n {{< reuse "docs/snippets/namespace.md" >}}
+```
+
+### Field defaulting
+
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide.
+
+#### `name` and `secretRef.key` both set
+
+kgateway sets the `name` header to the value of the `secretRef.key` data key in the Secret.
+
+```yaml
+headerModifiers:
+  response:
+    set:
+    - name: X-Response-Signature
+      secretRef:
+        name: response-signing
+        key: signing-key
+```
+
+#### `secretRef.key` omitted
+
+kgateway sets the `name` header to the value of the Secret data key that matches `name`.
+
+```yaml
+headerModifiers:
+  response:
+    set:
+    - name: X-Response-Signature
+      secretRef:
+        name: response-signing
+```
+
+#### `name` omitted
+
+kgateway sets a header named after `secretRef.key` to the value of that data key in the Secret.
+
+```yaml
+headerModifiers:
+  response:
+    set:
+    - secretRef:
+        name: response-signing
+        key: signing-key
+```
+
+#### Both `name` and `secretRef.key` omitted
+
+kgateway injects every entry in the Secret as a response header. Each data key becomes a header name.
+
+```yaml
+headerModifiers:
+  response:
+    set:
+    - secretRef:
+        name: response-signing
 ```
 
 {{< /version >}}

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -439,6 +439,119 @@ curl -vi localhost:8080/response-headers -H "host: headers.example"
    {{% /tab %}}
    {{< /tabs >}}
 
+{{< version include-if="2.3.x" >}}
+## Use a value from a Secret {#header-from-secret}
+
+If a response header value is sensitive, such as an audit signing key or a service-to-service token destined for a trusted client, you might not want to commit it to a manifest in plain text. You can source a response header value from a Kubernetes Secret by replacing `value` with `secretRef` on a `set` or `add` entry in a {{< reuse "docs/snippets/trafficpolicy.md" >}}. kgateway resolves the Secret at translation time, so the value never appears in the policy spec. If the Secret changes later, kgateway re-translates the affected policies automatically.
+
+{{< callout type="info" >}}
+This option is available only on the {{< reuse "docs/snippets/trafficpolicy.md" >}}. The Gateway API `HTTPRoute` `ResponseHeaderModifier` filter does not support `secretRef`.
+{{< /callout >}}
+
+The same defaulting rules and cross-namespace `ReferenceGrant` requirement that apply to [request headers from a Secret]({{< link-hextra path="/traffic-management/header-control/request-header/#header-from-secret" >}}) also apply here. The following example shows the basic flow for responses.
+
+1. Create a Secret that holds the value you want to inject.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: response-signing
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   type: Opaque
+   stringData:
+     signing-key: my-response-signing-key
+   EOF
+   ```
+
+2. Create an HTTPRoute for the httpbin app. The example selects the http Gateway that you created before you began.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: HTTPRoute
+   metadata:
+     name: httpbin-headers
+     namespace: httpbin
+   spec:
+     parentRefs:
+     - name: http
+       namespace: {{< reuse "docs/snippets/namespace.md" >}}
+     hostnames:
+       - headers.example
+     rules:
+       - backendRefs:
+           - name: httpbin
+             port: 8000
+   EOF
+   ```
+
+3. Create a {{< reuse "docs/snippets/trafficpolicy.md" >}} that sets a response header from the `response-signing` Secret. The following example attaches the {{< reuse "docs/snippets/trafficpolicy.md" >}} to the http Gateway.
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}
+   kind: {{< reuse "docs/snippets/trafficpolicy.md" >}}
+   metadata:
+     name: httpbin-secret-response-headers
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
+   spec:
+     targetRefs:
+     - group: gateway.networking.k8s.io
+       kind: Gateway
+       name: http
+     headerModifiers:
+       response:
+         set:
+         - name: X-Response-Signature
+           secretRef:
+             name: response-signing
+             key: signing-key
+   EOF
+   ```
+
+   The {{< reuse "docs/snippets/trafficpolicy.md" >}} `targetRefs` field does not accept a `namespace`. The policy must live in the same namespace as the resource it targets. To scope this example to a single HTTPRoute instead of the whole Gateway, change `kind` to `HTTPRoute` and `name` to the route's name, and create the {{< reuse "docs/snippets/trafficpolicy.md" >}} (and the Secret) in the route's namespace.
+
+   |Setting|Description|
+   |--|--|
+   |`headerModifiers.response.set.name`|The HTTP header name that the client receives. |
+   |`headerModifiers.response.set.secretRef.name`|The name of the Kubernetes Secret to read the value from. If the Secret does not exist when the policy is applied, the policy reports `Accepted=False` and the affected route returns a 500 response. |
+   |`headerModifiers.response.set.secretRef.key`|The key in the Secret's `data` to use as the header value. Optional. If `key` is omitted, it defaults to the value of `headerModifiers.response.set.name`. |
+   |`headerModifiers.response.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. Cross-namespace references require a `ReferenceGrant`. For details, see the request-header [Cross-namespace Secrets]({{< link-hextra path="/traffic-management/header-control/request-header/#cross-namespace-secrets" >}}) section. |
+
+4. Send a request to the httpbin app on the `headers.example` domain and confirm that the response includes the `X-Response-Signature` header with the value from the Secret.
+   {{< tabs items="Cloud Provider Loadbalancer,Port-forward for local testing" tabTotal="2" >}}
+   {{% tab tabName="Cloud Provider Loadbalancer" %}}
+   ```sh
+   curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.example:8080"
+   ```
+   {{% /tab %}}
+   {{% tab tabName="Port-forward for local testing" %}}
+   ```sh
+   curl -vi localhost:8080/response-headers -H "host: headers.example"
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+
+   Example output:
+   ```sh
+   HTTP/1.1 200 OK
+   access-control-allow-credentials: true
+   access-control-allow-origin: *
+   content-type: application/json; encoding=utf-8
+   x-envoy-upstream-service-time: 0
+   x-response-signature: my-response-signing-key
+   server: envoy
+   ```
+
+When you are finished, optionally clean up the resources that you created.
+
+```sh
+kubectl delete httproute httpbin-headers -n httpbin
+kubectl delete {{< reuse "docs/snippets/trafficpolicy.md" >}} httpbin-secret-response-headers -n {{< reuse "docs/snippets/namespace.md" >}}
+kubectl delete secret response-signing -n {{< reuse "docs/snippets/namespace.md" >}}
+```
+
+{{< /version >}}
+
 ## Dynamic response headers {#dynamic-response-header}
 
 You can return dynamic information about the response in the response header. For more information, see the Envoy docs for [Custom request/response headers](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#custom-request-response-headers).

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -515,7 +515,7 @@ The same defaulting rules and cross-namespace `ReferenceGrant` requirement that 
    |`headerModifiers.response.set.name`|The HTTP header name that the client receives. |
    |`headerModifiers.response.set.secretRef.name`|The name of the Kubernetes Secret to read the value from. If the Secret does not exist when the policy is applied, the policy reports `Accepted=False` and the affected route returns a 500 response. |
    |`headerModifiers.response.set.secretRef.key`|The key in the Secret's `data` to use as the header value. Optional. If `key` is omitted, it defaults to the value of `headerModifiers.response.set.name`. |
-   |`headerModifiers.response.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. Cross-namespace references require a `ReferenceGrant`. For details, see the request-header [Cross-namespace Secrets]({{< link-hextra path="/traffic-management/header-control/request-header/#cross-namespace-secrets" >}}) section. |
+   |`headerModifiers.response.set.secretRef.namespace`|The namespace of the Secret. Optional. If `namespace` is omitted, it defaults to the namespace of the {{< reuse "docs/snippets/trafficpolicy.md" >}}. Cross-namespace references require a `ReferenceGrant`.  |
 
 4. Send a request to the httpbin app on the `headers.example` domain and confirm that the response includes the `X-Response-Signature` header with the value from the Secret.
 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -553,7 +553,7 @@ kubectl delete secret response-signing -n {{< reuse "docs/snippets/namespace.md"
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide. If kgateway looks up a key that does not exist in the Secret, the policy reports `Accepted=False` and the affected route returns a 500 response.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide. If the Secret does not contain the the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### `name` and `secretRef.key` both set
 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -553,7 +553,7 @@ kubectl delete secret response-signing -n {{< reuse "docs/snippets/namespace.md"
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide. If the Secret does not contain the the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional. How kgateway resolves a header value depends on which combination of fields you provide. If the Secret does not contain the `key` or `name` data, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### `name` and `secretRef.key` both set
 

--- a/assets/docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/docs/pages/traffic-management/header-control/response-header.md
@@ -553,7 +553,7 @@ kubectl delete secret response-signing -n {{< reuse "docs/snippets/namespace.md"
 
 ### Field defaulting
 
-The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide.
+The `name` field on a `set` or `add` entry and the `key` field on `secretRef` are both optional, as long as at least one is set. How kgateway resolves a header value depends on which combination of fields you provide. If kgateway looks up a key that does not exist in the Secret, the policy reports `Accepted=False` and the affected route returns a 500 response.
 
 #### `name` and `secretRef.key` both set
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Added topics in the existing response and request headers to use secret information in the headers.

Related:
https://github.com/kgateway-dev/kgateway/issues/2751
https://github.com/kgateway-dev/kgateway/pull/3614
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind documentation
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
#### Secret-backed header values {#v23-header-secret-ref}

The {{< reuse "docs/snippets/trafficpolicy.md" >}} `headerModifiers` field now supports sourcing request and response header values from a Kubernetes Secret. Replace `value` with `secretRef` on a `set` or `add` entry to inject the Secret value as a header at the gateway. kgateway resolves the Secret at translation time and re-translates the affected policies automatically when the Secret changes, so the value never appears in the policy manifest. The header `name` and `secretRef.key` are both optional, and when both are omitted every entry in the Secret is injected as a header. Cross-namespace references require a `ReferenceGrant` in the Secret's namespace.

For more information, see [Use a value from a Secret]({{< link-hextra path="/traffic-management/header-control/request-header/#header-from-secret" >}}).

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
