### PR TITLE
v2.0.x not listed in hugo.yaml

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,1 @@
-[{"version": "2.3.x", "linkVersion": "main", "url": "main"}, {"version": "2.2.x", "linkVersion": "latest", "url": "latest"}, {"version": "2.1.x", "linkVersion": "2.1.x", "url": "2.1.x"}, {"version": "2.0.x", "linkVersion": "2.0.x", "url": "2.0.x"}]
+[{"version": "2.3.x", "linkVersion": "main", "url": "main"}, {"version": "2.2.x", "linkVersion": "latest", "url": "latest"}, {"version": "2.1.x", "linkVersion": "2.1.x", "url": "2.1.x"}]


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

the versions.json file was out of sync with hugo.yaml so I removed the version not present in hugo.yaml and was outdated.

# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```
