### PR TITLE
docs: removed trailing slash from origin examples

### DIFF
--- a/assets/docs/pages/security/cors.md
+++ b/assets/docs/pages/security/cors.md
@@ -185,7 +185,7 @@ EOF
 
 Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snippets/trafficpolicy.md" >}}, you can test the policies.
 
-1. Send a request to the httpbin app on the `cors.example` domain and use `https://example.com/` as the origin. Verify that your request succeeds and that you get back the configured CORS headers.
+1. Send a request to the httpbin app on the `cors.example` domain and use `https://example.com` as the origin. Verify that your request succeeds and that you get back the configured CORS headers.
    
    {{< tabs tabTotal="2" items="Cloud Provider LoadBalancer,Port-forward for local testing" >}}
    {{% tab tabName="Cloud Provider LoadBalancer" %}}

--- a/assets/docs/pages/security/cors.md
+++ b/assets/docs/pages/security/cors.md
@@ -191,7 +191,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    {{% tab tabName="Cloud Provider LoadBalancer" %}}
    ```sh
    curl -I -X OPTIONS http://$INGRESS_GW_ADDRESS:8080/get -H "host: cors.example:8080" \
-    -H "Origin: https://example.com/" \
+    -H "Origin: https://example.com" \
     -H "Access-Control-Request-Method: POST" \
     -H "Access-Control-Request-Headers: Origin"
    ```
@@ -199,7 +199,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    {{% tab tabName="Port-forward for local testing" %}}
    ```sh
    curl -I -X OPTIONS localhost:8080/headers -H "host: cors.example:8080" \
-    -H "Origin: https://example.com/" \
+    -H "Origin: https://example.com" \
     -H "Access-Control-Request-Method: POST" \
     -H "Access-Control-Request-Headers: Origin"
    ```
@@ -219,7 +219,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    content-length: 0
    
    HTTP/1.1 200 OK
-   access-control-allow-origin: https://example.com/
+   access-control-allow-origin: https://example.com
    access-control-allow-credentials: true
    access-control-allow-methods: GET, POST, OPTIONS
    access-control-allow-headers: Origin, Authorization, Content-Type
@@ -239,7 +239,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    content-length: 0
    
    HTTP/1.1 200 OK
-   access-control-allow-origin: https://example.com/
+   access-control-allow-origin: https://example.com
    access-control-allow-credentials: true
    access-control-allow-methods: GET, POST, OPTIONS
    access-control-allow-headers: Origin, Authorization, Content-Type
@@ -259,7 +259,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    content-length: 0
    
    HTTP/1.1 200 OK
-   access-control-allow-origin: https://example.com/
+   access-control-allow-origin: https://example.com
    access-control-allow-credentials: true
    access-control-allow-methods: GET, POST, OPTIONS
    access-control-allow-headers: Origin, Authorization, Content-Type
@@ -278,7 +278,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    {{% tab tabName="Cloud Provider LoadBalancer" %}}
    ```sh
    curl -I -X OPTIONS http://$INGRESS_GW_ADDRESS:8080/get -H "host: cors.example:8080" \
-    -H "Origin: https://notallowed.com/" \
+    -H "Origin: https://notallowed.com" \
     -H "Access-Control-Request-Method: POST" \
     -H "Access-Control-Request-Headers: Origin"
    ```
@@ -286,7 +286,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    {{% tab tabName="Port-forward for local testing" %}}
    ```sh
    curl -I -X OPTIONS localhost:8080/headers -H "host: cors.example:8080" \
-    -H "Origin: https://notallowed.com/" \
+    -H "Origin: https://notallowed.com" \
     -H "Access-Control-Request-Method: POST" \
     -H "Access-Control-Request-Headers: Origin"
    ```
@@ -304,7 +304,7 @@ Now that you have CORS policies applied via an HTTPRoute or {{< reuse "docs/snip
    access-control-allow-credentials: true
    access-control-allow-headers: Origin
    access-control-allow-methods: GET, POST, HEAD, PUT, DELETE, PATCH, OPTIONS
-   access-control-allow-origin: https://notallowed.com/
+   access-control-allow-origin: https://notallowed.com
    access-control-max-age: 3600
    date: Tue, 24 Jun 2025 13:21:20 GMT
    content-length: 0


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

fixed the origin header examples in the CORS docs.
browsers send origin without a trailing slash, so examples such as:

updated:   origin: https://example.com/
to:   origin: https://example.com

fixes kgateway-dev/kgateway#13997

# Change Type

```
/kind documentation
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```
