### PR TITLE
Docs experimental feature gate warning

### DIFF
--- a/content/docs/envoy/main/setup/listeners/tcp.md
+++ b/content/docs/envoy/main/setup/listeners/tcp.md
@@ -19,6 +19,13 @@ The following guide deploys a sample TCP echo app, sets up a TCP listener on the
    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
    ```
 
+{{< callout type="warning" >}}
+In kgateway 2.2 and later, experimental Gateway API features such as
+`TCPRoute` require the
+`KGW_ENABLE_EXPERIMENTAL_GATEWAY_API_FEATURES=true`
+environment variable to be enabled.
+{{< /callout >}}   
+
 3. {{< reuse "docs/snippets/prereq-listenerset.md" >}}
 
 4. Deploy the sample TCP echo app.

--- a/content/docs/envoy/main/setup/listeners/tls-termination-tcproute.md
+++ b/content/docs/envoy/main/setup/listeners/tls-termination-tcproute.md
@@ -15,6 +15,12 @@ Install the experimental channel of the {{< reuse "docs/snippets/k8s-gateway-api
 ```shell
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
 ```
+{{< callout type="warning" >}}
+In kgateway 2.2 and later, experimental Gateway API features such as
+`TLSRoute` require the
+`KGW_ENABLE_EXPERIMENTAL_GATEWAY_API_FEATURES=true`
+environment variable to be enabled.
+{{< /callout >}}
 
 ## Create a TLS certificate
 


### PR DESCRIPTION
# Description

Adds warnings to the TCPRoute and TLSRoute setup guides to clarify that experimental Gateway API features require the `KGW_ENABLE_EXPERIMENTAL_GATEWAY_API_FEATURES=true` environment variable in kgateway 2.2 and later.

This helps prevent configuration issues when following the setup documentation for experimental Gateway API features.

# Change Type

/kind documentation

# Additional Notes

Updated:

* `content/docs/envoy/main/setup/listeners/tcp.md`
* `content/docs/envoy/main/setup/listeners/tls-termination-tcproute.md`