### PR TITLE
Docs jwt release note example

### DIFF
--- a/content/docs/envoy/latest/reference/release-notes.md
+++ b/content/docs/envoy/latest/reference/release-notes.md
@@ -61,8 +61,38 @@ Several fields have been removed or changed in the `GatewayParameters` CRD:
 In the `TrafficPolicy` API:
 * The `jwt` field is renamed to `jwtAuth`
 * The `apiKeyAuthentication` field is renamed to `apiKeyAuth`
-
 Update your TrafficPolicy resources accordingly when upgrading.
+{{< callout type="warning" >}}
+When upgrading from v2.1 to v2.2, make sure to rename these fields in existing
+`TrafficPolicy` resources. Policies that continue using the old field names may
+not behave as expected after the upgrade.
+{{< /callout >}}
+
+**Before (v2.1):**
+
+```yaml
+spec:
+  jwt:
+    providers:
+      - name: my-provider
+
+  apiKeyAuthentication:
+    providers:
+      - name: my-api-key-provider
+```
+
+**After (v2.2+):**
+
+```yaml
+spec:
+  jwtAuth:
+    providers:
+      - name: my-provider
+
+  apiKeyAuth:
+    providers:
+      - name: my-api-key-provider
+```
 
 #### JWT missing token behavior {#jwt-missing-token}
 


### PR DESCRIPTION
## Summary

This PR improves the upgrade guidance for the `TrafficPolicy` API in the v2.2 release notes by adding a clear migration example for renamed authentication fields.

The current release notes mention that:
- `jwt` → `jwtAuth`
- `apiKeyAuthentication` → `apiKeyAuth`

However, they do not include an actionable example showing how to update existing `TrafficPolicy` resources.

This PR addresses that gap by adding:
- A warning callout about potential unexpected behavior when old fields are used after upgrade
- Before/After YAML examples for both JWT and API key authentication fields

## Motivation

Users upgrading from v2.1 → v2.2 may not realize they need to manually update existing `TrafficPolicy` resources. Without migration examples, the change is easy to miss and can lead to misconfigured authentication policies after upgrade.

## Change Type

/ kind documentation

## Changelog

```release-note
docs: add migration example for TrafficPolicy jwt/apiKey rename