### PR TITLE
fix: correct Canary lab link and UTM URL spaces in data files

### DIFF
--- a/data/labs.yaml
+++ b/data/labs.yaml
@@ -20,43 +20,43 @@
 
 - title: Gateway API support for service mesh with kgateway
   description: See how Kubernetes Gateway API supports service mesh with kgateway to manage and control internal east-west traffic with your system
-  href: https://www.solo.io/resources/lab/gatewayapi-support-for-service-mesh-with-kgateway?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/gatewayapi-support-for-service-mesh-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Understanding kgateway and Gateway API policy attachments
   description: Explore the Gateway API Policy Attachments pattern and learn how policies can extend gateways and routes
-  href: https://www.solo.io/resources/lab/understanding-kgateway-patterns-of-extensions?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/understanding-kgateway-patterns-of-extensions?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Canary releases with kgateway, Argo Rollouts & the Gateway API
   description: Explore how to conduct a canary release with kgateway using Argo RollOuts and the Gateway API plugin
-  href: https://www.solo.io/resources/lab/canary-releases-with-argo-rollouts-kgateway?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/canary-releases-with-argo-rollouts-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
   
 - title: Deploying kgateway as an AI Gateway
   description: Learn how to configure GatewayClass for AI gateways and provision kgateway for proxying LLMs
-  href: https://www.solo.io/resources/lab/deploying-kgateway-as-an-ai-gateway?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/deploying-kgateway-as-an-ai-gateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Prompt Guards in kgateway 
   description: Learn the fundamentals in ensuring your LLM content's safety with prompt guards in kgateway
-  href: https://www.solo.io/resources/lab/kgateway-ai-lab-prompt-guards?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/kgateway-ai-lab-prompt-guards?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Prompt Enrichment in kgateway 
   description: Explore how to manage your system and user prompts in LLMs with kgateway
-  href: https://www.solo.io/resources/lab/kgateway-ai-lab-prompt-enrichment?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/kgateway-ai-lab-prompt-enrichment?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Credentials Management in kgateway 
   description: Learn how to configure authorization and manage credentials across LLM providers with kgateway
-  href: https://www.solo.io/resources/lab/kgateway-ai-lab-credentials-management?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/kgateway-ai-lab-credentials-management?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Route Delegation in kgateway
   description: Explore route delegation in kgateway to enable multi-tenancy, self-service routing, and extended Kubernetes Gateway API capabilities
-  href: https://www.solo.io/resources/lab/route-delegation-in-kgateway?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/route-delegation-in-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
  
 - title: Gateway API inference extensions with kgateway
   description: Learn about the Gateway API Inference Extension in kgateway to enable intelligent AI request routing using Kubernetes-native resources and open source tools
-  href: https://www.solo.io/resources/lab/kgateway-lab-gateway-api-inference-extensions-with-kgateway?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/kgateway-lab-gateway-api-inference-extensions-with-kgateway?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
   
 - title: Consumption Reporting with kgateway AI
   description: Learn how an AI Gateway like kgateway provides built-in tools for monitoring, reporting, and controlling AI API consumption
-  href: https://www.solo.io/resources/lab/kgateway-ai-lab-consumption-reporting?web&utm_source=organic &utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
+  href: https://www.solo.io/resources/lab/kgateway-ai-lab-consumption-reporting?web&utm_source=organic&utm_medium=FY26&utm_campaign=WW_GEN_LAB_kgateway.dev&utm_content=community
 
 - title: Kgateway as a waypoint
   description: Learn how to use kgateway as a waypoint with Istio's ambient mode to manage east-west traffic between workloads

--- a/data/learningpaths.yaml
+++ b/data/learningpaths.yaml
@@ -36,7 +36,7 @@
     lab: understanding-kgateway-patterns-of-extensions
   - title: Canary Release with Argo
     youtube: nI52m7S5gLY
-    lab: understanding-kgateway-patterns-of-extensions
+    lab: canary-releases-with-argo-rollouts-kgateway
     blog: canary-deployments-argo-rollouts
 - id: kgw
   title: Kgateway Fundamentals


### PR DESCRIPTION
# Description

**Motivation:** Two bugs were found in the data files that affect 
user experience and analytics tracking.

**What changed:**

Bug 1 — `data/learningpaths.yaml`
The "Canary Release with Argo" lesson was pointing to the wrong lab
(copy-pasted from the "Policy Attachments" lesson above it).
Changed:
- From: `lab: understanding-kgateway-patterns-of-extensions`
- To: `lab: canary-releases-with-argo-rollouts-kgateway`

Bug 2 — `data/labs.yaml`
10 out of 17 lab href URLs had a space before `&utm_medium` which
malformed the UTM parameter, causing analytics to track 
utm_source as "organic " (with a space) instead of "organic".
Removed the extra space from all affected URLs.

**Related issues:** Fixes #778 

# Change Type

/kind fix
/kind documentation

# Changelog

```release-note
Fix wrong lab link for Canary Release lesson and malformed UTM 
URL spaces in data/learningpaths.yaml and data/labs.yaml.
```

# Additional Notes

Both fixes are in data files only. No docs content or 
site functionality was changed.