### PR TITLE
fix(docs): correct spec.targetRef to spec.targetRefs in TrafficPolicy

### DIFF
--- a/assets/docs/pages/about/trafficpolicy.md
+++ b/assets/docs/pages/about/trafficpolicy.md
@@ -67,7 +67,7 @@ Instead of applying the policy to all routes that are defined in an HTTPRoute re
 Attaching a policy via the `ExtensionRef` filter is legacy behavior and might be deprecated in a future release. Instead, use the [HTTPRoute rule attachment option](#attach-to-rule) to apply a policy to an individual route, which requires the Kubernetes Gateway API experimental channel version 1.3.0 or later. Also, the `ExtensionRef` filter is not supported for agentgateway proxies.
 {{< /callout >}}
 
-The following example shows a {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that defines a transformation rule. Note that the `spec.targetRef` field is not set. Because of that, the {{< reuse "docs/snippets/trafficpolicy.md" >}} does not apply until it is referenced in an HTTPRoute by using the `ExtensionRef` filter. 
+The following example shows a {{< reuse "docs/snippets/trafficpolicy.md" >}} resource that defines a transformation rule. Note that the `spec.targetRefs` field is not set. Because of that, the {{< reuse "docs/snippets/trafficpolicy.md" >}} does not apply until it is referenced in an HTTPRoute by using the `ExtensionRef` filter. 
 
 ```yaml
 apiVersion: {{< reuse "docs/snippets/trafficpolicy-apiversion.md" >}}


### PR DESCRIPTION
# Description

**Motivation:**
There was an inconsistency in the TrafficPolicy documentation where the "Individual route" section referenced `spec.targetRef`. This contradicts the actual API schema and all other examples on the page, which use the plural `spec.targetRefs`.

**What changed:**
Corrected `spec.targetRef` to `spec.targetRefs` in the TrafficPolicy documentation to ensure consistency and prevent user confusion during implementation.

# Change Type
/kind documentation
/kind fix

# Changelog

```release-note
Corrected a typo in the TrafficPolicy documentation; changed spec.targetRef to spec.targetRefs in the "Individual route" section to match the API schema.