### PR TITLE
fix(docs): separate BackendTLSPolicy into its own table to fix shortc…

### DIFF
--- a/assets/docs/snippets/k8sgwapi-exp.md
+++ b/assets/docs/snippets/k8sgwapi-exp.md
@@ -4,18 +4,11 @@ The following features are experimental in the upstream Kubernetes Gateway API p
 | --- | --- |
 | [ListenerSets]({{< link-hextra path="/setup/listeners/overview/#listenersets" >}}) | 1.3 |
 | [TCPRoutes]({{< link-hextra path="/setup/listeners/tcp/" >}}) | 1.3 |
+| [BackendTLSPolicy]({{< link-hextra path="/security/backend-tls/" >}}) | 1.4 |
 | [CORS policies]({{< link-hextra path="/security/cors/" >}}) | 1.2 |
 | [Retries]({{< link-hextra path="/resiliency/retry/" >}}) | 1.2 |
 | [Session persistence]({{< link-hextra path="/traffic-management/session-affinity/session-persistence" >}}) | 1.3 |
 | [HTTPRoute rule attachment option]({{< link-hextra path="/about/policies/trafficpolicy/#attach-to-rule" >}}) | 1.3 |
-
-{{< version exclude-if="2.0.x" >}}
-The following experimental features additionally require Gateway API v1.4 or later:
-
-| Feature | Minimum Gateway API version |
-| --- | --- |
-| [BackendTLSPolicy]({{< link-hextra path="/security/backend-tls/" >}}) | 1.4 |
-{{< /version >}}
 
 {{< version include-if="2.2.x,2.3.x" >}}
 {{< callout type="info" >}}

--- a/assets/docs/snippets/k8sgwapi-exp.md
+++ b/assets/docs/snippets/k8sgwapi-exp.md
@@ -3,12 +3,19 @@ The following features are experimental in the upstream Kubernetes Gateway API p
 | Feature | Minimum Gateway API version |
 | --- | --- |
 | [ListenerSets]({{< link-hextra path="/setup/listeners/overview/#listenersets" >}}) | 1.3 |
-| [TCPRoutes]({{< link-hextra path="/setup/listeners/tcp/" >}})| 1.3 |
-{{< version exclude-if="2.0.x" >}}| [BackendTLSPolicy]({{< link-hextra path="/security/backend-tls/" >}})| 1.4 |{{< /version >}}
+| [TCPRoutes]({{< link-hextra path="/setup/listeners/tcp/" >}}) | 1.3 |
 | [CORS policies]({{< link-hextra path="/security/cors/" >}}) | 1.2 |
 | [Retries]({{< link-hextra path="/resiliency/retry/" >}}) | 1.2 |
-| [Session persistence]({{< link-hextra path="/traffic-management/session-affinity/session-persistence" >}}) | 1.3 | 
+| [Session persistence]({{< link-hextra path="/traffic-management/session-affinity/session-persistence" >}}) | 1.3 |
 | [HTTPRoute rule attachment option]({{< link-hextra path="/about/policies/trafficpolicy/#attach-to-rule" >}}) | 1.3 |
+
+{{< version exclude-if="2.0.x" >}}
+The following experimental features additionally require Gateway API v1.4 or later:
+
+| Feature | Minimum Gateway API version |
+| --- | --- |
+| [BackendTLSPolicy]({{< link-hextra path="/security/backend-tls/" >}}) | 1.4 |
+{{< /version >}}
 
 {{< version include-if="2.2.x,2.3.x" >}}
 {{< callout type="info" >}}


### PR DESCRIPTION
# Description

**Motivation:** 
The feature maturity table for `BackendTLSPolicy` was failing to render correctly due to a Hugo shortcode limitation. Injecting a `{{< version >}}` shortcode inside a Markdown table causes the Hugo parser to prematurely close the table, breaking the layout.

**What changed:** 
Moved the `BackendTLSPolicy` row into its own separate table block. This ensures valid Markdown table syntax is maintained while still applying the necessary version filtering.

# Change Type
/kind documentation
/kind fix

# Changelog

```release-note
Fix rendering issue in feature maturity documentation for BackendTLSPolicy.
```
# Additional Notes

This change avoids the need to enable markup.goldmark.renderer.unsafe: true in the Hugo configuration, maintaining security standards while ensuring the docs render correctly in the browse