### PR TITLE
Add namespace to ALB configuration in documentation

### DIFF
--- a/assets/docs/pages/integrations/aws-elb/alb.md
+++ b/assets/docs/pages/integrations/aws-elb/alb.md
@@ -41,6 +41,7 @@ The AWS Load Balancer Controller only supports the creation of an ALB through an
    apiVersion: gateway.networking.k8s.io/v1
    metadata:
      name: alb
+     namespace: {{< reuse "docs/snippets/namespace.md" >}}
    spec:
      gatewayClassName: {{< reuse "docs/snippets/gatewayclass.md" >}}
      listeners:


### PR DESCRIPTION
## Description

Fixed a missing `namespace` field in the Gateway manifest example within the ALB integration documentation.
Without this field, the Gateway is created in the `default` namespace, but the subsequent HTTPRoute examples reference it via `parentRefs` with `namespace: kgateway-system`, causing the routes to fail.

## Change Type

- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] Other

## Changelog

```yaml
# Before
metadata:
  name: alb

# After
metadata:
  name: alb
  namespace: {{< reuse "docs/snippets/namespace.md" >}}
```

Added `namespace: {{< reuse "docs/snippets/namespace.md" >}}` to the Gateway manifest example in `assets/docs/pages/integrations/aws-elb/alb.md`.

## Additional Notes

Without the `namespace` field, the Gateway is created in the `default` namespace.
However, the subsequent HTTPRoute examples in the same guide reference the Gateway with `namespace: kgateway-system` in their `parentRefs`, so the routes would not work correctly without this fix.