### PR TITLE
docs: fix broken global policy card rendering on policy page

### DIFF
--- a/assets/docs/pages/about/policies-index.md
+++ b/assets/docs/pages/about/policies-index.md
@@ -47,7 +47,9 @@ Review the policies that you can configure in kgateway and the level at which yo
 | [Transformations](../../traffic-management/transformations) | {{< reuse "docs/snippets/trafficpolicy.md" >}} | 
 ## Policy behavior
 
+{{< version exclude-if="2.0.x" >}}
 {{< cards >}}
-{{< version exclude-if="2.0.x" >}}  {{< card link="global-attachment" title="Global policy attachment" >}}{{< /version >}}
+  {{< card link="global-attachment" title="Global policy attachment" >}}
   {{< card link="merging" title="Policy merging" >}}
 {{< /cards >}}
+{{< /version >}}


### PR DESCRIPTION
# Description

**Motivation:** The "Global policy attachment" card in the Policy behavior section was rendering as raw HTML on the live site instead of as a styled card, visible to all users at `/docs/envoy/latest/about/policies/`.

**What changed:**  Fixed by wrapping the entire `{{< cards >}}` block inside the `{{< version exclude-if="2.0.x" >}}` shortcode instead of nesting version inside cards. This is the same pattern already used in the Policy CRDs section directly above on the same page.

/kind fix

# Changelog

```release-note
Fixed raw HTML rendering of the Global policy attachment card in the Policy behavior section on the Policies landing page.
```

# Additional Notes

- The 2.0.x version correctly shows nothing under Policy behavior.  Neither card existed in that version, and the maintainer confirmed that 2.0.x docs will be removed entirely soon.
- The `include-if` parameter of the `{{< version >}}` shortcode is currently non-functional (checks page front matter instead of shortcode params). This is a separate issue and not addressed in this PR.