### PR TITLE
docs: update ArgoCD stable version

### DIFF
--- a/assets/docs/pages/install/argocd.md
+++ b/assets/docs/pages/install/argocd.md
@@ -9,7 +9,7 @@ In this installation guide, you install {{< reuse "/docs/snippets/kgateway.md" >
 3. If you do not already have Argo CD installed in your cluster, install it.
    ```shell
    kubectl create namespace argocd
-   until kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.12.3/manifests/install.yaml > /dev/null 2>&1; do sleep 2; done
+   until kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml > /dev/null 2>&1; do sleep 2; done
    # wait for deployment to complete
    kubectl -n argocd rollout status deploy/argocd-applicationset-controller
    kubectl -n argocd rollout status deploy/argocd-dex-server


### PR DESCRIPTION
# Description

**Motivation:** The ArgoCD install guide hardcodes `v2.12.3`, which reached end-of-life in early 2026 and no longer receives security patches. 

**What changed:** Replaced the hardcoded `v2.12.3` version with the `stable` floating tag in the ArgoCD install command.

/kind fix

# Changelog

```release-note
Updated ArgoCD install command from hardcoded EOL version v2.12.3 to the `stable` floating tag.
```
# Additional Notes

The `stable` tag is maintained by the ArgoCD project and always points to the latest stable release. Using it avoids the docs going stale on every ArgoCD release. 
Reference: https://github.com/argoproj/argo-cd/blob/stable/docs/getting_started.md