### PR TITLE
docs: fix broken links in path rewrite documentation

### DIFF
--- a/assets/docs/pages/traffic-management/rewrite/path.md
+++ b/assets/docs/pages/traffic-management/rewrite/path.md
@@ -1,6 +1,6 @@
 Rewrite path prefixes in requests by using the `URLRewrite` filter. 
 
-For more information, see the [{{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter).
+For more information, see the [{{< reuse "docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter).
 
 ## Before you begin
 
@@ -8,7 +8,7 @@ For more information, see the [{{< reuse "docs/snippets/k8s-gateway-api-name.md"
 
 ## Rewrite prefix path
 
-Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmodifiertype) to rewrite path prefixes. 
+Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httppathmodifiertype) to rewrite path prefixes. 
 
 ### In-cluster services
 
@@ -215,7 +215,7 @@ Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/spec/#httpp
 
 ## Rewrite full path
 
-Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmodifiertype) to rewrite full paths. 
+Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httppathmodifiertype) to rewrite full paths. 
 
 ### In-cluster services
 


### PR DESCRIPTION
# Description

- **Motivation:** The path rewrite documentation contained broken links that could confuse users trying to configure traffic management.
- **What changed:** Corrected the broken links and updated the text in `assets/docs/pages/traffic-management/rewrite/path.md`.

# Change Type

/kind documentation
/kind fix

# Changelog

```release-note
docs: Fix broken links in the traffic management path rewrite documentation