### PR TITLE
fix: resolve windows compatibility and encoding issues in generator scripts

### DIFF
--- a/scripts/generate-ref-docs.py
+++ b/scripts/generate-ref-docs.py
@@ -12,6 +12,19 @@ import subprocess
 import os
 import re
 import platform
+import shutil
+import stat
+
+
+def safe_rmtree(path):
+    '''Safely remove a directory tree, handling read-only permissions on Windows'''
+    def _remove_readonly(func, p, excinfo):
+        os.chmod(p, stat.S_IWRITE)
+        func(p)
+
+    if os.path.exists(path):
+        shutil.rmtree(path, onerror=_remove_readonly)
+
 
 
 def resolve_tag_for_version(version, link_version):
@@ -79,8 +92,7 @@ def resolve_branch_for_version(version, link_version):
 def clone_repository(ref, kgateway_dir='kgateway'):
     '''Clone the kgateway repository at the specified branch or tag'''
     # Clean up any existing directory
-    if os.path.exists(kgateway_dir):
-        subprocess.run(['rm', '-rf', kgateway_dir], check=True)
+    safe_rmtree(kgateway_dir)
     
     # Clone repository
     if ref == 'main':
@@ -762,7 +774,7 @@ def main():
             print(f'   ⚠ Metrics docs failed: {e}')
         
         # Clean up repository after processing this version
-        subprocess.run(['rm', '-rf', 'kgateway'], check=True)
+        safe_rmtree('kgateway')
         
         print(f'✅ Completed version {version} - generated {success_count}/3 doc types')
     

--- a/scripts/generate-shared-types.py
+++ b/scripts/generate-shared-types.py
@@ -161,7 +161,7 @@ def parse_go_file(filepath: Path, source: str = "", is_enterprise: bool = False)
     """Parse a Go file and extract type definitions."""
     types = []
     
-    content = filepath.read_text()
+    content = filepath.read_text(encoding="utf-8")
     lines = content.split('\n')
     
     # Find type definitions
@@ -364,7 +364,7 @@ def find_documented_types(doc_file: Path) -> set[str]:
     if not doc_file.exists():
         return set()
 
-    content = doc_file.read_text()
+    content = doc_file.read_text(encoding="utf-8")
     heading_pattern = re.compile(r'^#### (\w+)', re.MULTILINE)
     return {m.group(1) for m in heading_pattern.finditer(content)}
 
@@ -374,7 +374,7 @@ def find_all_broken_links(doc_file: Path) -> set[str]:
     if not doc_file.exists():
         return set()
 
-    content = doc_file.read_text()
+    content = doc_file.read_text(encoding="utf-8")
 
     # Find all links like [TypeName](#typename)
     link_pattern = re.compile(r'\[([A-Z][A-Za-z0-9_]*)\]\(#([a-z][a-z0-9_]*)\)')
@@ -482,7 +482,7 @@ def main():
     markdown = generate_markdown(all_types, referenced, existing_doc_types)
     
     # Append to doc file
-    with open(doc_file, "a") as f:
+    with open(doc_file, "a", encoding="utf-8") as f:
         f.write(markdown)
     
     print(f"Successfully appended documentation for {len(referenced)} types")


### PR DESCRIPTION
# Description

- **Motivation:** Running reference documentation and shared types generator scripts crashed on Windows systems due to Unix-specific command dependencies and default system text encoding.
- 
- **What changed:** 
- 
  1. Replaced Unix-specific `rm -rf` subprocess calls in `generate-ref-docs.py` with Python's cross-platform `shutil.rmtree` combined with a permission handler to bypass Windows `.git` folder file locks.
  2. Specified explicit `encoding="utf-8"` in all text file read/write operations in `generate-shared-types.py` to prevent `UnicodeDecodeError` on Windows systems.
- **Related issues:** Fixes #801 

# Change Type

/kind fix
/kind documentation

# Changelog

```release-note
fix: resolve windows compatibility and encoding issues in generator scripts