### PR TITLE
Automatic populating of version cards

### DIFF
--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -47,3 +47,19 @@ hugoWarnings = [
   "\\.Site\\.Data was deprecated",
   "'items' parameter of the 'tabs' shortcode is deprecated",
 ]
+
+# console-errors (browser-smoke) suppressions. Each pattern is matched
+# (as a RegExp) against the full error string; for uncaught exceptions the
+# string includes the stack, so a pattern can be scoped to the source file.
+consoleErrors = [
+  # Hextra's vendored js/main.min.<hash>.js wires the sidebar/hamburger on
+  # EVERY page at DOMContentLoaded and calls `.hextra-sidebar-container`
+  # .removeAttribute("aria-hidden") without a null guard. On the ~70 pages
+  # with no docs sidebar (homepage, /blog/ + posts, /docs/ landing, resources,
+  # learn, marketing) it throws "Cannot read properties of null (reading
+  # 'removeAttribute')". Not fixable in docs-theme-extras (it's the minified
+  # upstream bundle). Scoped to the message AND the Hextra bundle filename via
+  # the stack frame, so it cannot mask a removeAttribute error from our own or
+  # the theme's JS. Versioned docs pages have the sidebar and are unaffected.
+  "reading 'removeAttribute'\\)[\\s\\S]*main\\.min\\.[0-9a-f]+\\.js",
+]

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ framework-test-install:  ## Install Playwright + browsers in the extras checkout
 .PHONY: framework-test
 framework-test:  ## Build, then run the full Playwright harness (static + browser + cross-browser)
 	@$(MAKE) _framework_test_preflight
+	rm -rf public
 	hugo160 --gc --minify > .build.log 2>&1
 	cd $(FRAMEWORK_EXTRAS_DIR) && \
 		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test; \
@@ -52,6 +53,7 @@ framework-test:  ## Build, then run the full Playwright harness (static + browse
 .PHONY: framework-test-static
 framework-test-static:  ## Build, then run only the static (no-browser) specs â€” fastest loop
 	@$(MAKE) _framework_test_preflight
+	rm -rf public
 	hugo160 --gc --minify > .build.log 2>&1
 	cd $(FRAMEWORK_EXTRAS_DIR) && \
 		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test --project=static; \
@@ -62,6 +64,7 @@ framework-test-static:  ## Build, then run only the static (no-browser) specs â€
 .PHONY: framework-test-browser
 framework-test-browser:  ## Build, then run the chromium browser specs
 	@$(MAKE) _framework_test_preflight
+	rm -rf public
 	hugo160 --gc --minify > .build.log 2>&1
 	cd $(FRAMEWORK_EXTRAS_DIR) && \
 		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test --project=browser; \
@@ -72,6 +75,7 @@ framework-test-browser:  ## Build, then run the chromium browser specs
 .PHONY: framework-test-cross-browser
 framework-test-cross-browser:  ## Build, then run cross-browser specs (chromium + firefox + webkit)
 	@$(MAKE) _framework_test_preflight
+	rm -rf public
 	hugo160 --gc --minify > .build.log 2>&1
 	cd $(FRAMEWORK_EXTRAS_DIR) && \
 		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test \

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -14,15 +14,15 @@ Kgateway provides a control plane that manages the following data plane proxies.
 
 <div class="hx:block hx:dark:hidden">
 {{< cards >}}
-  {{< card link="/docs/envoy/latest/" title="Kgateway with Envoy" subtitle="Envoy-based data plane for secure API management of ingress, egress, and service mesh traffic. Written in C++." image="/img/logo-Envoy_Final_BLACK.png" imageStyle="height: 200px; object-fit: contain; width: 60%; margin: 0 auto; display: block;">}}
-  {{< card link="https://agentgateway.dev/docs/kubernetes/latest/" title="Agentgateway" subtitle="AI-first gateway for connectivity across agents, MCP tools, LLMs, and inferences. Written in Rust." image="/img/logo-agentgateway-transparent.png" imageStyle="height: 200px; object-fit: contain; width: 100%; margin: 0 auto; display: block;">}}
+  {{< card link="/docs/envoy/latest/" title="Kgateway with Envoy" subtitle="Envoy-based data plane for secure API management of ingress, egress, and service mesh traffic. Written in C++." image="assets/img/logo-Envoy_Final_BLACK.png" imageStyle="height: 200px; object-fit: contain; width: 60%; margin: 0 auto; display: block;">}}
+  {{< card link="https://agentgateway.dev/docs/kubernetes/latest/" title="Agentgateway" subtitle="AI-first gateway for connectivity across agents, MCP tools, LLMs, and inferences. Written in Rust." image="assets/img/logo-agentgateway-transparent.png" imageStyle="height: 200px; object-fit: contain; width: 100%; margin: 0 auto; display: block;">}}
 {{< /cards >}}
 </div>
 
 <div class="hx:hidden hx:dark:block">
 {{< cards >}}
-  {{< card link="/docs/envoy/latest/" title="Kgateway with Envoy" subtitle="Envoy-based data plane for secure API management of ingress, egress, and service mesh traffic. Written in C++." image="/img/logo-Envoy_Final_WHITE.png" imageStyle="height: 200px; object-fit: contain; width: 80%; margin: 0 auto; display: block;">}}
-  {{< card link="https://agentgateway.dev/docs/kubernetes/latest/" title="Agentgateway" subtitle="AI-first gateway for connectivity across agents, MCP tools, LLMs, and inferences. Written in Rust." image="/img/logo-agentgateway-light-on-transparent.png" imageStyle="height: 200px; object-fit: contain; width: 100%; margin: 0 auto; display: block;">}}
+  {{< card link="/docs/envoy/latest/" title="Kgateway with Envoy" subtitle="Envoy-based data plane for secure API management of ingress, egress, and service mesh traffic. Written in C++." image="assets/img/logo-Envoy_Final_WHITE.png" imageStyle="height: 200px; object-fit: contain; width: 80%; margin: 0 auto; display: block;">}}
+  {{< card link="https://agentgateway.dev/docs/kubernetes/latest/" title="Agentgateway" subtitle="AI-first gateway for connectivity across agents, MCP tools, LLMs, and inferences. Written in Rust." image="assets/img/logo-agentgateway-light-on-transparent.png" imageStyle="height: 200px; object-fit: contain; width: 100%; margin: 0 auto; display: block;">}}
 {{< /cards >}}
 </div>
 

--- a/content/docs/envoy/_index.md
+++ b/content/docs/envoy/_index.md
@@ -6,9 +6,5 @@ disableCards: true
 ---
 # Kgateway Docs (Envoy-based API gateway)
 
-Select the version for the kgateway docs.
-{{< cards >}}
-  {{< card link="/docs/envoy/latest/" title="2.3 (latest)" subtitle="Current stable release" >}}
-  {{< card link="/docs/envoy/2.2.x/" title="2.2" subtitle="Previous stable release" >}}
-  {{< card link="/docs/envoy/2.1.x/" title="2.1" subtitle="Previous stable release" >}}
-{{< /cards >}}
+
+{{< version-cards desc="Select the version for the kgateway docs." >}}

--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.0.2 // indirect
-
+require github.com/solo-io/docs-theme-extras v0.0.3-beta.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.0.3-beta.1 // indirect
+require github.com/solo-io/docs-theme-extras v0.0.3-beta.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.0.3-beta.2 // indirect
+require github.com/solo-io/docs-theme-extras v0.0.3-beta.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.0.3-beta.5 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.0.3-beta.5 h1:v8OtPb5GZxfrD7/zi06thq30SqxBMrOvAOBXXEV3jMM=
 github.com/solo-io/docs-theme-extras v0.0.3-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.0 h1:FkUnc4p7OrAEa8VCoZMdIr9nHfZjH8kS00LSAacuUNM=
+github.com/solo-io/docs-theme-extras v0.1.0/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.0.2 h1:crZWFU43T3d/Cf7/shOfYbhlOMDPq3NByQ8a2E1ZjcE=
 github.com/solo-io/docs-theme-extras v0.0.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.1 h1:waiBsy00r5WK5oQJZZ0u6lL28Biu8jRkg+dIgQtKWZA=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.0.2 h1:crZWFU43T3d/Cf7/shOfYbhlOMDPq3NByQ8a2E1ZjcE=
-github.com/solo-io/docs-theme-extras v0.0.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.0.3-beta.1 h1:waiBsy00r5WK5oQJZZ0u6lL28Biu8jRkg+dIgQtKWZA=
-github.com/solo-io/docs-theme-extras v0.0.3-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.0.3-beta.2 h1:e6eJfC12fg5ALIA3KA6SDvnCxVHmssQ8xsjcZ1nNfHA=
-github.com/solo-io/docs-theme-extras v0.0.3-beta.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.5 h1:v8OtPb5GZxfrD7/zi06thq30SqxBMrOvAOBXXEV3jMM=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/solo-io/docs-theme-extras v0.0.2 h1:crZWFU43T3d/Cf7/shOfYbhlOMDPq3NBy
 github.com/solo-io/docs-theme-extras v0.0.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
 github.com/solo-io/docs-theme-extras v0.0.3-beta.1 h1:waiBsy00r5WK5oQJZZ0u6lL28Biu8jRkg+dIgQtKWZA=
 github.com/solo-io/docs-theme-extras v0.0.3-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.2 h1:e6eJfC12fg5ALIA3KA6SDvnCxVHmssQ8xsjcZ1nNfHA=
+github.com/solo-io/docs-theme-extras v0.0.3-beta.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/layouts/_partials/nav.html
+++ b/layouts/_partials/nav.html
@@ -157,7 +157,7 @@
 </nav>
 
 <div class="mobile-nav absolute bg-primary-text w-screen z-40">
-  <div class="h-full flex flex-col px-4 items-stretch justify-end w-screen">
+  <div class="h-full flex flex-col px-4 items-stretch justify-start pt-28 w-screen">
     <a class="whitespace-nowrap text-[1.5625rem] text-white border-b border-[#545454] py-5" href="/resources/labs">Labs</a>
     <a class="whitespace-nowrap text-[1.5625rem] text-white border-b border-[#545454] py-5" href="/resources/videos">Videos</a>
     <a class="whitespace-nowrap text-[1.5625rem] text-white border-b border-[#545454] py-5" href="/blog">Blog</a>


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Replaces the hardcoded version cards in content/docs/envoy/_index.md with {{< version-cards >}} so the version list is auto-populated from the versions TOML instead of requiring a manual update on each release. Bumps docs-theme-extras to v0.1.0, which ships the shortcode.

Additional fixes included in this PR:

- Updates card image paths in content/docs/_index.md from root-relative /img/... to assets/img/... so images are resolved through Hugo's asset pipeline and published correctly.
- Fixes the mobile nav menu alignment in nav.html (justify-end → justify-start pt-28) so nav items render at the top of the overlay instead of the bottom.
- Adds rm -rf public before each framework test build target in the Makefile so stale build artifacts don't carry over between runs.
- Suppresses the Hextra removeAttribute null-dereference console error in .docs-test.toml. The error comes from Hextra's minified main.min.js on pages without a docs sidebar (homepage, blog, marketing) and is not fixable in this repo.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind documentation
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
