### PR TITLE
docs: use correct petstore.yaml across versions for uninstallation guide

### DIFF
--- a/assets/docs/pages/operations/uninstall.md
+++ b/assets/docs/pages/operations/uninstall.md
@@ -190,5 +190,5 @@ Remove any optional components that you no longer need, such as sample apps.
 3. Remove the Petstore sample app.
    
    ```sh
-   kubectl delete -f https://raw.githubusercontent.com/kgateway-dev/kgateway.dev/{{< reuse "docs/versions/github-branch.md" >}}/assets/docs/examples/petstore.yaml
+   kubectl delete -f https://raw.githubusercontent.com/solo-io/gloo/v1.16.x/example/petstore/petstore.yaml
    ```

--- a/assets/docs/pages/operations/uninstall.md
+++ b/assets/docs/pages/operations/uninstall.md
@@ -186,9 +186,3 @@ Remove any optional components that you no longer need, such as sample apps.
    ```sh
    kubectl delete -f https://raw.githubusercontent.com/kgateway-dev/kgateway/refs/heads/{{< reuse "docs/versions/github-branch.md" >}}/examples/httpbin.yaml
    ```
-
-3. Remove the Petstore sample app.
-   
-   ```sh
-   kubectl delete -f https://raw.githubusercontent.com/solo-io/gloo/v1.16.x/example/petstore/petstore.yaml
-   ```


### PR DESCRIPTION
# Description

This PR fixes a broken, cut-off uninstallation URL for the Petstore sample application.

- **Motivation:** While a native copy of `petstore.yaml` is introduced on only `main` branch of `kgateway-dev/kgateway.dev` (`assets/docs/examples/petstore.yaml`) therefore `petstore.yaml` file for versions other than main does not resolve. Hardcoding a native `main` branch link across versioned documentation pages of both installation and uninstallation causes confusion for users working in specific version contexts.
- **What changed:** To ensure a consistent, stable, and better user experience across all versions of the documentation, like the installation, cleanup section has been configured to point to the `solo-io/gloo` manifest.
  - **Install Section:** Pointed `kubectl apply` to the stable `solo-io/gloo/v1.16.x` manifest.
  - **Cleanup Section:** Fixed the broken/cut-off line and pointed `kubectl delete` to the matching stable `solo-io/gloo/v1.16.x` manifest.

# Change Type

/kind documentation

# Changelog

```release-note
docs: fix petstore example URLs across versioned guides