### PR TITLE
Removed glooctl command for the config_dump url

### DIFF
--- a/assets/docs/snippets/debug-gateway.md
+++ b/assets/docs/snippets/debug-gateway.md
@@ -27,7 +27,7 @@
    Review the following table of common endpoints that can help troubleshoot your setup further.
    | Endpoint | Description| 
    | -- | -- | 
-   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated in to Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied invalid configuration that was rejected by Envoy. To get the proxy configuration directly, open `http://localhost:19000/config_dump`. | 
+   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated into an Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied an invalid configuration that was rejected by Envoy. To get the proxy configuration directly, open `http://localhost:19000/config_dump`. | 
    | listeners | See the listeners that are configured on your gateway. | 
    | logging | Review the log level that is set for each component. |  
    | stats/prometheus | View metrics that Envoy emitted and sent to the built-in Prometheus instance. |

--- a/assets/docs/snippets/debug-gateway.md
+++ b/assets/docs/snippets/debug-gateway.md
@@ -27,7 +27,7 @@
    Review the following table of common endpoints that can help troubleshoot your setup further.
    | Endpoint | Description| 
    | -- | -- | 
-   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated in to Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied invalid configuration that is rejected Envoy. To get the proxy configuration directly, open `http://localhost:19000/config_dump`. | 
+   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated in to Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied invalid configuration that was rejected by Envoy. To get the proxy configuration directly, open `http://localhost:19000/config_dump`. | 
    | listeners | See the listeners that are configured on your gateway. | 
    | logging | Review the log level that is set for each component. |  
    | stats/prometheus | View metrics that Envoy emitted and sent to the built-in Prometheus instance. |

--- a/assets/docs/snippets/debug-gateway.md
+++ b/assets/docs/snippets/debug-gateway.md
@@ -27,7 +27,7 @@
    Review the following table of common endpoints that can help troubleshoot your setup further.
    | Endpoint | Description| 
    | -- | -- | 
-   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated in to Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied invalid configuration that is rejected Envoy. You can also use `{{< reuse "docs/snippets/cli-name.md" >}} proxy dump` to get the Envoy proxy configuration. | 
+   | config_dump | Get the configuration that is available in the Envoy proxy. Any kgateway resources that you create are translated in to Envoy configuration. Depending on whether or not you enabled resource validation, you might have applied invalid configuration that is rejected Envoy. To get the proxy configuration directly, open `http://localhost:19000/config_dump`. | 
    | listeners | See the listeners that are configured on your gateway. | 
    | logging | Review the log level that is set for each component. |  
    | stats/prometheus | View metrics that Envoy emitted and sent to the built-in Prometheus instance. |


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Removed glooctl command and replaced with with config_dump localhost url.
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind documentation
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
