### PR TITLE
docs: fix spelling typos and documentation errors

### DIFF
--- a/assets/docs/pages/setup/listener-mtls.md
+++ b/assets/docs/pages/setup/listener-mtls.md
@@ -20,7 +20,7 @@ In this guide, you learn how to apply default certificate validation configurati
 Throughout this guide, you use self-signed TLS certificates for the Certificate Authority. These certificates are used to sign the TLS certificates for the gateway proxy (server) and httpbin client. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 ## Before you begin
@@ -38,7 +38,7 @@ Self-signed certificates are used for demonstration purposes. Do not use self-si
 Create self-signed TLS certificates that you use for the mutual TLS connection between your client application (`curl`) and the gateway proxy. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 <!-- >
@@ -508,7 +508,7 @@ In this example, you override the default certificate validation configuration f
 
 ## Additional TLS settings
 
-You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or CSDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
+You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or ECDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
 
 
 1. Get the certificate hash of the client certificate. 

--- a/content/blog/design-kgateway-for-scalability.md
+++ b/content/blog/design-kgateway-for-scalability.md
@@ -77,7 +77,7 @@ EOF
 
 3. **(Optional)** Install the [OpenTelemetry Collector](https://kgateway.dev/docs/envoy/latest/observability/otel-stack/) and [kube-prometheus-stack](https://kgateway.dev/docs/envoy/latest/observability/gateway-metrics/) to observe CPU, memory and Envoy metrics. (Make sure your cluster has adequate resources if doing this.)
 
-4. Clone the [kgateway repo](https://github.com/kgateway-dev/kgateway). From the cloned directory, use the `applier` utilitiy to load 10,000 routes and backends (from 0 to 9999). Send a few random requests to confirm routes are effective immediately.
+4. Clone the [kgateway repo](https://github.com/kgateway-dev/kgateway). From the cloned directory, use the `applier` utility to load 10,000 routes and backends (from 0 to 9999). Send a few random requests to confirm routes are effective immediately.
 
 ```bash
 cd hack/utils/applier

--- a/content/blog/exploring-gateway-api-httproute.md
+++ b/content/blog/exploring-gateway-api-httproute.md
@@ -205,7 +205,7 @@ However, when traffic comes in on the `/direct-response` path, the gateway will 
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: httpbin-direct-resonse
+  name: httpbin-direct-response
   namespace: httpbin
 spec:
   parentRefs:

--- a/content/blog/nginx-ingress-retirement-what-you-need-to-know.md
+++ b/content/blog/nginx-ingress-retirement-what-you-need-to-know.md
@@ -6,7 +6,7 @@ author: Lin Sun & Michael Levan
 excludeSearch: true
 ---
 
-During KubeConNA last week, the Kubernetes community [announced](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) the **Ingress NGINX retirement** and recommended that users move to the **Gateway API**, which is the modern replacement for Ingress. Best-effort maintenance of Ingress NGINX will continue until **March 2026**, meaning users need a migration plan soon.
+During KubeCon NA last week, the Kubernetes community [announced](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) the **Ingress NGINX retirement** and recommended that users move to the **Gateway API**, which is the modern replacement for Ingress. Best-effort maintenance of Ingress NGINX will continue until **March 2026**, meaning users need a migration plan soon.
 
 This announcement is significant—Ingress NGINX has been one of the most popular ingress controllers for traffic into Kubernetes clusters. It’s part of the core Kubernetes project with over 19,000 stars on [GitHub](https://github.com/kubernetes/ingress-nginx). In this blog, we’ll share key considerations to help you choose a replacement.
 

--- a/content/blog/securing-egress-traffic-with-kgateway-istio-ambient-mesh-and-kyverno-lfx-mentorship-blog.md
+++ b/content/blog/securing-egress-traffic-with-kgateway-istio-ambient-mesh-and-kyverno-lfx-mentorship-blog.md
@@ -79,7 +79,7 @@ This separation lets platform teams choose when L7 processing is necessary, redu
 
 ## kgateway's integration with Ambient Mesh
 kgateway integrates to Ambient Mesh for managing our workloads through Layer 4 and Layer 7 network policies. But the thing that sets its apart from other Gateway solutions is that, kgateway is the first project that can be used as a pluggable waypoint for Istio. 
-kgateway has been built on same Envoy engine that Istio’s waypoint implementation uses, which has certain features including Istio API Compatability, Shared Observability, Faster Adoption of Security Features and Unified Configuration Model with Ambient Mesh.
+kgateway has been built on same Envoy engine that Istio’s waypoint implementation uses, which has certain features including Istio API Compatibility, Shared Observability, Faster Adoption of Security Features and Unified Configuration Model with Ambient Mesh.
 
 ## Prepare your kgateway environment
 Before integrating kgateway with Istio Ambient, ensure we have: 
@@ -414,13 +414,13 @@ Through this Blog we addressed one of the most overlooked challenges in service 
 </div>
 
 # My LFX Mentorship Experience
-It's always great to contribute to a project and gain skills, experience, expertise and knowledge while working on certain different features of that project, but one of the most important part of contributing to an open source or being a part of an amazing project like kgateway is building up a strong confidence towards the future of the project and building up a commitement for the future to keep contributing as much value back to the project, to keep project's growth gain a consistent or exponential growth sustainably over the interval.
+It's always great to contribute to a project and gain skills, experience, expertise and knowledge while working on certain different features of that project, but one of the most important part of contributing to an open source or being a part of an amazing project like kgateway is building up a strong confidence towards the future of the project and building up a commitment for the future to keep contributing as much value back to the project, to keep project's growth gain a consistent or exponential growth sustainably over the interval.
 
 This is only possible with project's strong aim to solve problems in the most required format and with a strong community which is committed to keep the things **Up and Running**, inspired in a direction to solve issues that really messes around with the minds and tasks of the Developers but still remains ignored amid its complexity. 
 
 For a Mentee, his Mentors are the faces of the entire project's community, on which they are working! Thus, it wouldn't have been possible without the help of my Mentors - **Nina Polshakova** who kept helping me in the journey of this entire mentorship with every PR added & weekly targets, while contributing constantly to the latest Release v2.1 of kgateway with its first and biggest integration with agentgateway, and **Lin Sun** who helped me and the presiding the entire open source community while managing projects like agentgateway and kagent while working on kgateway's latest release v2.1!
 
-Community at **Kgateway** have been constantly focussing to solve issues which revolves around integration, observability, Security, AI collaboration and Governance implementing the Kubernetes Gateway API with a control plane that scales from lightweight microgateway deployments between services, to massively parallel centralized gateways handling billions of API calls. Community have been markign a huge impact by managing projects that can really impact the Workload orchestration and management through projects like:
+Community at **Kgateway** have been constantly focussing to solve issues which revolves around integration, observability, Security, AI collaboration and Governance implementing the Kubernetes Gateway API with a control plane that scales from lightweight microgateway deployments between services, to massively parallel centralized gateways handling billions of API calls. Community have been marking a huge impact by managing projects that can really impact the Workload orchestration and management through projects like:
 - **kgateway** to focus on control plane while integrating with Envoy-based data plane for secure API management of ingress, egress and service mesh.
 - **agentgateway** to provide an AI-first enterprise data plane for connectivity across agents, MCP tools, LLMs and interferences written in Rust.
 
@@ -429,7 +429,7 @@ It's always a good idea to go through the project and interact with the communit
 
 For me, **the value that the project have been adding to the entire landscape matters the most**. kgateway attracted my attention with its contributions, which made me to go through the documentation and even make a [YouTube Video](https://www.youtube.com/watch?v=RWQbUvVBUTI), explaining about Architecture of kgateway's Control Plane & Data Plane components, and Project's Deployment Patterns, before the mentorship was even announced!
 
-For collaborating with the community Members, I tied attending Community Meetings and even organized a [Podcast](https://www.youtube.com/watch?v=raWq9Q0Pmws) with my Mentor **Lin Sun** on my [YouTube channel](https://www.youtube.com/@AryanParashar_) on the ocassion of kgateway getting accepted as a CNCF Sandbox Project, where I tried understanding about the kgateway community's future goals, its capabilities which sets it apart from other gateway projects and get to know about the experiences of the kgateway's community members who have have been leading and contributing to the entire Kubernetes Project!
+For collaborating with the community Members, I tied attending Community Meetings and even organized a [Podcast](https://www.youtube.com/watch?v=raWq9Q0Pmws) with my Mentor **Lin Sun** on my [YouTube channel](https://www.youtube.com/@AryanParashar_) on the occasion of kgateway getting accepted as a CNCF Sandbox Project, where I tried understanding about the kgateway community's future goals, its capabilities which sets it apart from other gateway projects and get to know about the experiences of the kgateway's community members who have have been leading and contributing to the entire Kubernetes Project!
 
 These community collaborations and experiences attracted my attention to feel that working closely and contributing to this Project can really increase my experience and then LFX Mentorship came up as the best opportunity for me to get myself involved deeply within the Project and it's capabilities!
 
@@ -442,7 +442,7 @@ Working on a Mentorship Project can be really exciting that has been bound to th
 5. **Reflect your Technical Experience**: prove your technical expertise through actual code contributions.
 6. **Participation in Community**: Participate in Community's slack channel, Community Meetings to understand the future goals, Present requirements and problems that users are experiencing and maintain Regularly sync progress with mentors
 
-### My Contributions made during Mentoship
+### My Contributions made during Mentorship
 During this mentorship, I had the opportunity to work across several areas of the kgateway ecosystem, contributing through hands-on development, documentation improvements, and technical deep dives including: 
 1. Documentation for ServiceEntries management with kgateway and Istio.
 2. Fixing Bugs in **exAuth** Policies of kgateway.
@@ -451,7 +451,7 @@ During this mentorship, I had the opportunity to work across several areas of th
 5. Building Security integration of kgateway with Istio and Kyverno for its exAuth and CEL based Authz testing policies.
 6. Running Demo for Security integration of kgateway with Istio & Kyverno.
 7. Contributing to **Argo Rollouts** integration to kgateway, while using **agentgateway** as its gatewayClass.
-8. Advocating for kgateway project through a demo video on my Youtube channel with its agentgaetway integration in version v2.1 and MCP walkthrough.
+8. Advocating for kgateway project through a demo video on my Youtube channel with its agentgateway integration in version v2.1 and MCP walkthrough.
 
 ## Mentorship Conclusion
 My LFX Mentorship with the kgateway community has been much more than completing weekly tasks or shipping a handful of PRs — it has fundamentally shaped how I think about open-source collaboration, real-world infrastructure design, and the responsibility that comes with contributing to a CNCF ecosystem project. This journey helped me understand the true depth of modern API gateways, the evolving role of Ambient Mesh, and how governance, observability, security, and automation must work together to create reliable platforms.

--- a/content/docs/envoy/2.0.x/traffic-management/header-control/response-header.md
+++ b/content/docs/envoy/2.0.x/traffic-management/header-control/response-header.md
@@ -244,7 +244,7 @@ curl -vi http://$INGRESS_GW_ADDRESS:8080/response-headers -H "host: headers.exam
 {{% /tab %}}
 {{% tab tabName="Port-forward for local testing" %}}
 ```sh
-curl -vi localhost:8080/reesponse-headers -H "host: headers.example"
+curl -vi localhost:8080/response-headers -H "host: headers.example"
 ```
 {{% /tab %}}
    {{< /tabs >}}

--- a/content/docs/envoy/2.0.x/traffic-management/transformations/templating-language.md
+++ b/content/docs/envoy/2.0.x/traffic-management/transformations/templating-language.md
@@ -72,7 +72,7 @@ Learn more about the template attributes that you can use to transform headers a
 
 ### `add`, `set`, `remove`
 
-Apply transformation templates to add, set, or remode request or response headers. 
+Apply transformation templates to add, set, or remove request or response headers. 
 
 #### Static value
 

--- a/content/docs/envoy/latest/setup/listeners/mtls.md
+++ b/content/docs/envoy/latest/setup/listeners/mtls.md
@@ -25,7 +25,7 @@ In this guide, you learn how to apply default certificate validation configurati
 Throughout this guide, you use self-signed TLS certificates for the Certificate Authority. These certificates are used to sign the TLS certificates for the gateway proxy (server) and httpbin client. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 ## Before you begin
@@ -37,7 +37,7 @@ Self-signed certificates are used for demonstration purposes. Do not use self-si
 Create self-signed TLS certificates that you use for the mutual TLS connection between your client application (`curl`) and the gateway proxy. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 <!-- >
@@ -507,7 +507,7 @@ In this example, you override the default certificate validation configuration f
 
 ## Additional TLS settings
 
-You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or CSDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
+You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or ECDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
 
 
 1. Get the certificate hash of the client certificate. 

--- a/content/docs/envoy/main/setup/listeners/mtls.md
+++ b/content/docs/envoy/main/setup/listeners/mtls.md
@@ -25,7 +25,7 @@ In this guide, you learn how to apply default certificate validation configurati
 Throughout this guide, you use self-signed TLS certificates for the Certificate Authority. These certificates are used to sign the TLS certificates for the gateway proxy (server) and httpbin client. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 ## Before you begin
@@ -37,7 +37,7 @@ Self-signed certificates are used for demonstration purposes. Do not use self-si
 Create self-signed TLS certificates that you use for the mutual TLS connection between your client application (`curl`) and the gateway proxy. 
 
 {{< callout type="warning" >}}
-Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trust Certificate Authority. 
+Self-signed certificates are used for demonstration purposes. Do not use self-signed certificates in production environments. Instead, use certificates that are issued from a trusted Certificate Authority. 
 {{< /callout >}}
 
 <!-- >
@@ -507,7 +507,7 @@ In this example, you override the default certificate validation configuration f
 
 ## Additional TLS settings
 
-You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or CSDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
+You can configure your mTLS listener to limit connections to clients that present a certificate with a specific certificate hash and Subject Alternative Names. Alternatively, you can configure your listeners to enforce other TLS settings, such as a minimum or maximum TLS version, specific cipher suites, or ECDH curves. For more information, see [Additional TLS settings]({{< link-hextra path="/setup/listeners/tls-settings/" >}}). 
 
 
 1. Get the certificate hash of the client certificate. 


### PR DESCRIPTION
# Description

This PR fixes several minor spelling errors, typos, and versioned file inconsistencies across the `kgateway` documentation pages and blog posts. These corrections improve the readability, professional tone, and searchability of the website.

- **Motivation:** Fix typos and improve documentation quality for users reading the website.
- **What changed:** Corrected typos in mTLS docs, response headers, templating languages, and several blog posts (scalability, HTTPRoute, NGINX retirement, and LFX egress mesh blogs).
- **Related issues:** Fixes #837 

# Change Type
/kind documentation

# Changelog
```release-note
Fix various typos and spelling errors in the documentation and blog posts.