### PR TITLE
docs: reuse shared gateway metrics content

### DIFF
--- a/assets/docs/pages/observability/gateway-metrics.md
+++ b/assets/docs/pages/observability/gateway-metrics.md
@@ -2,7 +2,7 @@ By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Promet
 
 ## View default data plane metrics in Prometheus {#prometheus-metrics}
 
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment.
+The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment. {{< version exclude-if="2.0.x" >}}To integrate the Prometheus metrics into your observability stack, see the [OpenTelemetry guide]({{< link-hextra path="/observability/otel-stack/" >}}).{{< /version >}}
 
 1. Port-forward the gateway deployment on port 19000.
    

--- a/assets/docs/pages/observability/gateway-metrics.md
+++ b/assets/docs/pages/observability/gateway-metrics.md
@@ -7,7 +7,7 @@ The following steps show you how to quickly view the metrics endpoint of the gat
 1. Port-forward the gateway deployment on port 19000.
    
    ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
+   kubectl -n {{< reuse "/docs/snippets/namespace.md" >}} port-forward deployment/http 19000
    ```
 
 2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).

--- a/assets/docs/pages/observability/gateway-metrics.md
+++ b/assets/docs/pages/observability/gateway-metrics.md
@@ -1,0 +1,24 @@
+By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
+
+## View default data plane metrics in Prometheus {#prometheus-metrics}
+
+The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment.
+
+1. Port-forward the gateway deployment on port 19000.
+   
+   ```sh
+   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
+   ```
+
+2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
+
+   Example output:
+
+   ```console
+   # TYPE envoy_cluster_external_upstream_rq counter
+   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
+   ```
+
+## Gateway proxy metrics reference {#reference}
+
+For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).

--- a/content/docs/envoy/2.0.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.0.x/observability/gateway-metrics.md
@@ -3,27 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
-
-## View default data plane metrics in Prometheus {#prometheus-metrics}
-
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment.
-
-1. Port-forward the gateway deployment on port 19000.
-   
-   ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
-   ```
-
-2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
-
-   Example output:
-
-   ```console
-   # TYPE envoy_cluster_external_upstream_rq counter
-   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
-   ```
-
-## Gateway proxy metrics reference {#reference}
-
-For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).
+{{< reuse "docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/2.0.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.0.x/observability/gateway-metrics.md
@@ -3,4 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/gateway-metrics.md" >}}
+{{< reuse "/docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/2.1.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.1.x/observability/gateway-metrics.md
@@ -3,4 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/gateway-metrics.md" >}}
+{{< reuse "/docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/2.1.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.1.x/observability/gateway-metrics.md
@@ -3,27 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
-
-## View default data plane metrics in Prometheus {#prometheus-metrics}
-
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment. To integrate the Prometheus metrics into your observability stack, see the [OpenTelemetry guide]({{< link-hextra path="/observability/otel-stack/" >}}).
-
-1. Port-forward the gateway deployment on port 19000.
-   
-   ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
-   ```
-
-2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
-
-   Example output:
-
-   ```console
-   # TYPE envoy_cluster_external_upstream_rq counter
-   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
-   ```
-
-## Gateway proxy metrics reference {#reference}
-
-For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).
+{{< reuse "docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/2.2.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.2.x/observability/gateway-metrics.md
@@ -3,4 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/gateway-metrics.md" >}}
+{{< reuse "/docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/2.2.x/observability/gateway-metrics.md
+++ b/content/docs/envoy/2.2.x/observability/gateway-metrics.md
@@ -3,27 +3,4 @@ title: Gateway proxy metrics
 weight: 20
 ---
 
-By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
-
-## View default data plane metrics in Prometheus {#prometheus-metrics}
-
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment. To integrate the Prometheus metrics into your observability stack, see the [OpenTelemetry guide]({{< link-hextra path="/observability/otel-stack/" >}}).
-
-1. Port-forward the gateway deployment on port 19000.
-   
-   ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
-   ```
-
-2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
-
-   Example output:
-
-   ```console
-   # TYPE envoy_cluster_external_upstream_rq counter
-   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
-   ```
-
-## Gateway proxy metrics reference {#reference}
-
-For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).
+{{< reuse "docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/latest/observability/gateway-metrics.md
+++ b/content/docs/envoy/latest/observability/gateway-metrics.md
@@ -4,27 +4,4 @@ description: Scrape Envoy proxy metrics from gateway pods to track request rates
 weight: 20
 ---
 
-By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
-
-## View default data plane metrics in Prometheus {#prometheus-metrics}
-
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment. To integrate the Prometheus metrics into your observability stack, see the [OpenTelemetry guide]({{< link-hextra path="/observability/otel-stack/" >}}).
-
-1. Port-forward the gateway deployment on port 19000.
-   
-   ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
-   ```
-
-2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
-
-   Example output:
-
-   ```console
-   # TYPE envoy_cluster_external_upstream_rq counter
-   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
-   ```
-
-## Gateway proxy metrics reference {#reference}
-
-For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).
+{{< reuse "docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/latest/observability/gateway-metrics.md
+++ b/content/docs/envoy/latest/observability/gateway-metrics.md
@@ -4,4 +4,4 @@ description: Scrape Envoy proxy metrics from gateway pods to track request rates
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/gateway-metrics.md" >}}
+{{< reuse "/docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/main/observability/gateway-metrics.md
+++ b/content/docs/envoy/main/observability/gateway-metrics.md
@@ -4,27 +4,4 @@ description: Scrape Envoy proxy metrics from gateway pods to track request rates
 weight: 20
 ---
 
-By default, {{< reuse "/docs/snippets/kgateway.md" >}} exposes metrics in Prometheus format for the data plane of each gateway proxy. You can use these metrics to monitor the health and performance of your gateway environment.
-
-## View default data plane metrics in Prometheus {#prometheus-metrics}
-
-The following steps show you how to quickly view the metrics endpoint of the gateway proxy deployment. To integrate the Prometheus metrics into your observability stack, see the [OpenTelemetry guide]({{< link-hextra path="/observability/otel-stack/" >}}).
-
-1. Port-forward the gateway deployment on port 19000.
-   
-   ```sh
-   kubectl -n {{< reuse "docs/snippets/namespace.md" >}} port-forward deployment/http 19000
-   ```
-
-2. Access the gateway metrics by reviewing the [Prometheus statistics `/stats/prometheus` endpoint](http://localhost:19000/stats/prometheus).
-
-   Example output:
-
-   ```console
-   # TYPE envoy_cluster_external_upstream_rq counter
-   envoy_cluster_external_upstream_rq{envoy_response_code="200",envoy_cluster_name="kube_httpbin_httpbin_8000"} 5
-   ```
-
-## Gateway proxy metrics reference {#reference}
-
-For more details about the collected metrics, see the [Envoy statistics reference docs](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview).
+{{< reuse "docs/pages/observability/gateway-metrics.md" >}}

--- a/content/docs/envoy/main/observability/gateway-metrics.md
+++ b/content/docs/envoy/main/observability/gateway-metrics.md
@@ -4,4 +4,4 @@ description: Scrape Envoy proxy metrics from gateway pods to track request rates
 weight: 20
 ---
 
-{{< reuse "docs/pages/observability/gateway-metrics.md" >}}
+{{< reuse "/docs/pages/observability/gateway-metrics.md" >}}


### PR DESCRIPTION
- Extract gateway metrics page content into a shared reusable asset
- Update all versioned gateway metrics docs to use the shared `reuse`
  shortcode
- Keep version-specific front matter in each docs page

issue #832 