### PR TITLE
docs link fixes for docs gen

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,17 @@
 
 This directory contains scripts and tools that help build the kgateway website and documentation.
 
+## Link fix-ups
+
+`generate-ref-docs.py` regenerates the API, Helm, and metrics reference docs from the kgateway repository. Some of those docs contain links that come straight from upstream source comments (Go doc comments and Helm `values.yaml`). When such a link breaks, the real fix belongs in the kgateway source, but the reference docs are also regenerated nightly from **released** kgateway tags, which are immutable. That means a broken URL keeps reappearing for already-released versions even after upstream source is corrected.
+
+`scripts/link-fixups.json` is the safety net. Each entry maps a broken `old` URL to a working `new` URL, and the generator rewrites every occurrence in the generated content for all versions. To add a fix-up:
+
+1. Append an entry to `scripts/link-fixups.json` with the broken URL (`old`), the working URL (`new`), and a short `reason`.
+2. Also fix the link in the kgateway source so new releases ship the correct URL; this file only patches docs generated from older, frozen releases.
+
+Matching is plain substring replacement, not regex.
+
 ## Unit tests
 
 Unit tests for scripts in this directory live in `scripts/tests/`.
@@ -28,6 +39,7 @@ The tests for `generate-ref-docs.py` check that the script:
 - Resolves the expected branch or release tag for a docs version.
 - Skips prerelease tags such as release candidates and beta releases when choosing the latest stable tag.
 - Calls `generate-shared-types.py` with the expected inputs when shared Go types are present.
+- Rewrites every broken link in `scripts/link-fixups.json` to its working URL, leaves already-correct links untouched, and tolerates a missing fix-ups file.
 
 These tests replace real `git` subprocess calls with test doubles so they run quickly and do not require network access.
 

--- a/scripts/generate-ref-docs.py
+++ b/scripts/generate-ref-docs.py
@@ -16,6 +16,54 @@ import shutil
 import stat
 
 
+_LINK_FIXUPS_CACHE = None
+
+
+def _load_link_fixups(path='scripts/link-fixups.json'):
+    '''Load the list of broken->working link replacements (cached).
+
+    Returns a list of {old, new} dicts. Missing or malformed files are treated
+    as "no fix-ups" so doc generation never fails just because the fix-up file
+    is absent.
+    '''
+    global _LINK_FIXUPS_CACHE
+    if _LINK_FIXUPS_CACHE is not None:
+        return _LINK_FIXUPS_CACHE
+
+    fixups = []
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            fixups = data.get('replacements', [])
+        except (json.JSONDecodeError, OSError) as e:
+            print(f'    Warning: could not load link fixups from {path}: {e}')
+    _LINK_FIXUPS_CACHE = fixups
+    return fixups
+
+
+def _apply_link_fixups(content):
+    '''Rewrite known-broken links in generated content.
+
+    Links sourced from immutable kgateway release tags can't be fixed at the
+    source for already-released versions, so we rewrite them here. See
+    scripts/link-fixups.json for the mapping and rationale.
+    '''
+    total = 0
+    for fixup in _load_link_fixups():
+        old = fixup.get('old')
+        new = fixup.get('new')
+        if not old or new is None:
+            continue
+        occurrences = content.count(old)
+        if occurrences:
+            content = content.replace(old, new)
+            total += occurrences
+    if total:
+        print(f'    ✓ Applied {total} link fixup(s)')
+    return content
+
+
 def safe_rmtree(path):
     '''Safely remove a directory tree, handling read-only permissions on Windows'''
     def _remove_readonly(func, p, excinfo):
@@ -451,6 +499,9 @@ def _post_process_api_docs(api_file):
     #    (Goldmark turns "\<" into a literal "<"). Unescape it to a real break.
     content = re.sub(r'\\(<br\s*/?>)', r'\1', content)
 
+    # Rewrite any known-broken links restored from upstream source comments.
+    content = _apply_link_fixups(content)
+
     with open(api_file, 'w') as f:
         f.write(content)
 
@@ -672,7 +723,10 @@ def generate_helm_docs(version, link_version, url_path, kgateway_dir='kgateway')
             else:
                 swapped_lines.append(line)
         content = '\n'.join(swapped_lines)
-        
+
+        # Rewrite any known-broken links restored from upstream values.yaml comments.
+        content = _apply_link_fixups(content)
+
         with open(helm_file, 'w', encoding='utf-8') as f:
             f.write(content)
         
@@ -701,8 +755,10 @@ def generate_metrics_docs(version, link_version, url_path, kgateway_dir='kgatewa
         '--markdown', f'./{kgateway_dir}'
     ], capture_output=True, text=True, check=True)
     
+    metrics_content = _apply_link_fixups(result.stdout)
+
     with open(f'assets/docs/snippets/{link_version}/metrics-control-plane.md', 'w') as f:
-        f.write(result.stdout)
+        f.write(metrics_content)
     
     print(f'    ✓ Generated metrics docs in assets/docs/snippets/{link_version}/metrics-control-plane.md')
     return True

--- a/scripts/link-fixups.json
+++ b/scripts/link-fixups.json
@@ -1,0 +1,57 @@
+{
+  "_comment": [
+    "Link fix-ups applied to generated reference docs (API, Helm, metrics).",
+    "",
+    "Some links live in kgateway source comments (Go doc comments, Helm values.yaml).",
+    "When those comments contain a URL that has since broken, the fix must land in the",
+    "kgateway repo's source. But the reference docs here are regenerated nightly from",
+    "released kgateway tags (2.x.y), which are immutable -- so the broken URL keeps",
+    "coming back for already-released versions even after upstream source is fixed.",
+    "",
+    "Each entry below rewrites an exact 'old' URL string to 'new' during doc generation,",
+    "so the published docs stay correct regardless of which upstream tag is rendered.",
+    "Matching is plain substring replacement (not regex) and runs over the full",
+    "generated content of every version.",
+    "",
+    "To add a fix-up: append an entry with the broken URL ('old'), the working URL",
+    "('new'), and a short 'reason'. Also fix the source in the kgateway repo so new",
+    "releases ship the correct link; this file is the safety net for older releases."
+  ],
+  "replacements": [
+    {
+      "old": "https://kgateway.dev/docs/operations/install/#namespace-discovery",
+      "new": "https://kgateway.dev/docs/envoy/latest/install/advanced/#namespace-discovery",
+      "reason": "Helm discoveryNamespaceSelectors doc link; the operations/install path 404s."
+    },
+    {
+      "old": "https://kgateway.dev/docs/latest/install/advanced/#namespace-discovery",
+      "new": "https://kgateway.dev/docs/envoy/latest/install/advanced/#namespace-discovery",
+      "reason": "Helm discoveryNamespaceSelectors doc link; docs are served under /docs/envoy/."
+    },
+    {
+      "old": "https://kgateway.dev/docs/integrations/inference-extension/",
+      "new": "https://kgateway.dev/docs/envoy/2.0.x/integrations/inference-extension/",
+      "reason": "Helm inferenceExtension doc link; docs are served under /docs/envoy/{version}/."
+    },
+    {
+      "old": "https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+      "new": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
+      "reason": "Kubernetes moved assign-pod-node from concepts/configuration to concepts/scheduling-eviction."
+    },
+    {
+      "old": "https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter",
+      "new": "https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter",
+      "reason": "Gateway API spec reference moved under /reference/api-spec/main/spec/."
+    },
+    {
+      "old": "https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html",
+      "new": "https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html",
+      "reason": "IETF retired tools.ietf.org; drafts now live on datatracker.ietf.org."
+    },
+    {
+      "old": "https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md",
+      "new": "https://github.com/kubernetes/community/blob/main/contributors/devel/sig-api-machinery/strategic-merge-patch.md",
+      "reason": "kubernetes/community renamed its default branch from master to main."
+    }
+  ]
+}

--- a/scripts/tests/test_link_fixups.py
+++ b/scripts/tests/test_link_fixups.py
@@ -1,0 +1,52 @@
+import json
+
+
+def test_shipped_fixups_rewrite_known_broken_links(gen_ref_docs):
+    '''Every entry in scripts/link-fixups.json should rewrite its broken URL.'''
+    with open("scripts/link-fixups.json") as f:
+        replacements = json.load(f)["replacements"]
+
+    assert replacements, "expected at least one shipped fix-up"
+
+    for entry in replacements:
+        old, new = entry["old"], entry["new"]
+        content = f"prefix {old} suffix"
+        result = gen_ref_docs._apply_link_fixups(content)
+        assert old not in result, f"broken link not rewritten: {old}"
+        assert new in result, f"replacement URL missing: {new}"
+
+
+def test_apply_link_fixups_is_substring_replacement(gen_ref_docs, monkeypatch):
+    monkeypatch.setattr(
+        gen_ref_docs,
+        "_LINK_FIXUPS_CACHE",
+        [{"old": "http://old.example/x", "new": "http://new.example/y"}],
+    )
+    content = "see http://old.example/x and http://old.example/x again"
+    result = gen_ref_docs._apply_link_fixups(content)
+    assert result == "see http://new.example/y and http://new.example/y again"
+
+
+def test_apply_link_fixups_leaves_correct_links_untouched(gen_ref_docs, monkeypatch):
+    monkeypatch.setattr(
+        gen_ref_docs,
+        "_LINK_FIXUPS_CACHE",
+        [{"old": "http://old.example/x", "new": "http://new.example/y"}],
+    )
+    content = "http://new.example/y stays as is"
+    assert gen_ref_docs._apply_link_fixups(content) == content
+
+
+def test_apply_link_fixups_skips_incomplete_entries(gen_ref_docs, monkeypatch):
+    monkeypatch.setattr(
+        gen_ref_docs,
+        "_LINK_FIXUPS_CACHE",
+        [{"old": "", "new": "http://x"}, {"old": "http://y"}],
+    )
+    content = "untouched http://y here"
+    assert gen_ref_docs._apply_link_fixups(content) == content
+
+
+def test_load_link_fixups_missing_file_returns_empty(gen_ref_docs, monkeypatch):
+    monkeypatch.setattr(gen_ref_docs, "_LINK_FIXUPS_CACHE", None)
+    assert gen_ref_docs._load_link_fixups("scripts/does-not-exist.json") == []


### PR DESCRIPTION
# Description

Reference docs are regenerated nightly from kgateway release tags like `v2.1.3`, so broken links sourced from upstream source comments keep reappearing for already-released versions even after the source is fixed. (see example PR: https://github.com/kgateway-dev/kgateway.dev/pull/861/)

Add `scripts/link-fixups.json` to map broken URLs to working ones, applied across API, Helm, and metrics doc generation. Seed it with the six links the nightly regen keeps restoring, document the mechanism in the scripts README, and add unit tests.

# Change Type

/kind documentation

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
