### PR TITLE
Fix leader election disable docs

### DIFF
--- a/assets/kgw-docs/pages/install/advanced.md
+++ b/assets/kgw-docs/pages/install/advanced.md
@@ -53,12 +53,12 @@ controller:
 
 Leader election is enabled by default to ensure that you can run {{< reuse "kgw-docs/snippets/kgateway.md" >}} in a multi-control plane replica setup for high availability. 
 
-You can disable leader election by setting the `controller.disableLeaderElection` to `true` in your Helm chart. 
+You can disable leader election by setting the `KGW_DISABLE_LEADER_ELECTION` environment variable to `"true"` through the `controller.extraEnv` Helm value.
 
 ```yaml
-
 controller:
-  disableLeaderElection: true
+  extraEnv:
+    KGW_DISABLE_LEADER_ELECTION: "true"
 ```
 
 

--- a/content/blog/kgateway v2.1 release blog.md
+++ b/content/blog/kgateway v2.1 release blog.md
@@ -120,10 +120,10 @@ When you install the [OTel stack](/docs/envoy/latest/observability/otel-stack/),
 
 Leader election is now enabled by default to ensure that you can run kgateway in a multi-control plane replica setup for high availability. 
 
-You can disable leader election by setting the `controller.disableLeaderElection` to `true` in your Helm chart. 
+You can disable leader election by setting the `KGW_DISABLE_LEADER_ELECTION` environment variable to `"true"` through the `controller.extraEnv` Helm value.
 
 ```sh
-helm upgrade -i --namespace kgateway-system --version v2.1.0 kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set controller.disableLeaderElection=true
+helm upgrade -i --namespace kgateway-system --version v2.1.0 kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set-string controller.extraEnv.KGW_DISABLE_LEADER_ELECTION=true
 ```
 
 ## 🔥 Breaking changes from the previous release

--- a/content/docs/envoy/2.1.x/reference/release-notes.md
+++ b/content/docs/envoy/2.1.x/reference/release-notes.md
@@ -251,10 +251,10 @@ When you install the [OTel stack]({{< link-hextra path="/observability/otel-stac
 
 Leader election is now enabled by default to ensure that you can run kgateway in a multi-control plane replica setup for high availability. 
 
-You can disable leader election by setting the `controller.disableLeaderElection` to `true` in your Helm chart. 
+You can disable leader election by setting the `KGW_DISABLE_LEADER_ELECTION` environment variable to `"true"` through the `controller.extraEnv` Helm value.
 
 ```sh
-helm upgrade -i --namespace kgateway-system --version v{{< reuse "kgw-docs/versions/n-patch.md" >}} kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set controller.disableLeaderElection=true
+helm upgrade -i --namespace kgateway-system --version v{{< reuse "docs/versions/n-patch.md" >}} kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set-string controller.extraEnv.KGW_DISABLE_LEADER_ELECTION=true
 ```
 
 

--- a/content/docs/envoy/2.1.x/reference/release-notes.md
+++ b/content/docs/envoy/2.1.x/reference/release-notes.md
@@ -254,7 +254,7 @@ Leader election is now enabled by default to ensure that you can run kgateway in
 You can disable leader election by setting the `KGW_DISABLE_LEADER_ELECTION` environment variable to `"true"` through the `controller.extraEnv` Helm value.
 
 ```sh
-helm upgrade -i --namespace kgateway-system --version v{{< reuse "docs/versions/n-patch.md" >}} kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set-string controller.extraEnv.KGW_DISABLE_LEADER_ELECTION=true
+helm upgrade -i --namespace kgateway-system --version v{{< reuse "kgw-docs/versions/n-patch.md" >}} kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set-string controller.extraEnv.KGW_DISABLE_LEADER_ELECTION=true
 ```
 
 


### PR DESCRIPTION
closed #860 
 - Replace the documented `controller.disableLeaderElection` Helm value with the implemented `controller.extraEnv.KGW_DISABLE_LEADER_ELECTION` configuration.
  - Update the 2.1 release notes and release blog Helm examples to use `--set-string`.

