### PR TITLE
docs: add JWT processing order documentation

### DIFF
--- a/assets/kgw-docs/snippets/jwt-about.md
+++ b/assets/kgw-docs/snippets/jwt-about.md
@@ -41,8 +41,4 @@ The JWT signature is used to verify the token's integrity and authenticity. The 
 
 ### JWT processing order {#processing-order}
 
-In kgateway OSS, JWT validation runs **before** external authentication by default. The gateway validates the JWT signature and extracts claims before any external auth policy is applied. This order is fixed and not configurable in OSS.
-
-{{< callout type="info" >}}
-**Note:** The `beforeExtAuth` and `afterExtAuth` staging options are available only in [Enterprise kgateway](https://docs.solo.io/kgateway/2.1.x/security/jwt/staging/). In OSS, the order is fixed.
-{{< /callout >}}
+In kgateway, JWT validation runs **before** external authentication by default. The gateway validates the JWT signature and extracts claims before any external auth policy is applied. This order is fixed and not currently configurable.

--- a/assets/kgw-docs/snippets/jwt-about.md
+++ b/assets/kgw-docs/snippets/jwt-about.md
@@ -38,3 +38,11 @@ JWT parts are structured as follows:
 ### JWT verification {#verification}
 
 The JWT signature is used to verify the token's integrity and authenticity. The signature is typically created by using asymmetric encryption with a private and public key. The JWT token is signed by using the private key. To verify the token, a public key is used. The public key can be shared and distributed because it cannot be used to sign new JWTs.
+
+### JWT processing order {#processing-order}
+
+In kgateway OSS, JWT validation runs **before** external authentication by default. The gateway validates the JWT signature and extracts claims before any external auth policy is applied. This order is fixed and not configurable in OSS.
+
+{{< callout type="info" >}}
+**Note:** The `beforeExtAuth` and `afterExtAuth` staging options are available only in [Enterprise kgateway](https://docs.solo.io/kgateway/2.1.x/security/jwt/staging/). In OSS, the order is fixed.
+{{< /callout >}}


### PR DESCRIPTION
# Description

This PR adds documentation for the JWT processing order in OSS kgateway.

- **Motivation:** Based on testing, we confirmed that JWT validation runs before external authentication in OSS. This default behavior needs to be documented.
- **What changed:** Added a new "JWT processing order" section to `assets/kgw-docs/snippets/jwt-about.md`
- **Related issues:** N/A

# Change Type

/kind documentation

# Changelog

```release-note
docs: add JWT processing order documentation

# Additional Notes
- JWT runs before ext-auth by default in OSS
- The order is fixed and not configurable
- `beforeExtAuth`/`afterExtAuth` is Enterprise-only
