### PR TITLE
Revised framework content tests

### DIFF
--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -19,6 +19,11 @@ brand   = "oss"
 builtRoot = "./public"
 baseURL   = "/"
 
+# Hugo build log for hugo-warnings.spec. The Makefile targets and the CI build
+# step write the Hugo build output here; the spec scans it for ERROR / WARN
+# lines (filtered by [allowlists].hugoWarnings).
+buildLog  = "./.build.log"
+
 # Source-tree roots for author-side lints (curl-quotes scans markdown
 # directly). Narrowed to docs content so the lint doesn't trip on blog
 # posts and marketing copy that follow looser conventions.

--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -33,13 +33,6 @@ scanRoots = [
 versionFromPath = "^/docs/(?:envoy|agentgateway)/(?<version>[^/]+)/"
 versions        = ["main", "latest", "2.2.x", "2.1.x", "2.0.x"]
 
-# All checks default to enabled. Turn off the slow / opt-in projects.
-[checks]
-# Smoke is for cross-product runs (SMOKE_PRODUCT env); kgateway is a
-# single site, so skip.
-smoke        = false
-crossBrowser = false
-
 # Allowlists for known-benign noise that surfaces against real product
 # content (test fixture has none of this). Tighten as content is fixed.
 [allowlists]

--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -50,14 +50,15 @@ hugoWarnings = [
 # (as a RegExp) against the full error string; for uncaught exceptions the
 # string includes the stack, so a pattern can be scoped to the source file.
 consoleErrors = [
-  # Hextra's vendored js/main.min.<hash>.js wires the sidebar/hamburger on
-  # EVERY page at DOMContentLoaded and calls `.hextra-sidebar-container`
-  # .removeAttribute("aria-hidden") without a null guard. On the ~70 pages
-  # with no docs sidebar (homepage, /blog/ + posts, /docs/ landing, resources,
-  # learn, marketing) it throws "Cannot read properties of null (reading
-  # 'removeAttribute')". Not fixable in docs-theme-extras (it's the minified
-  # upstream bundle). Scoped to the message AND the Hextra bundle filename via
-  # the stack frame, so it cannot mask a removeAttribute error from our own or
-  # the theme's JS. Versioned docs pages have the sidebar and are unaffected.
-  "reading 'removeAttribute'\\)[\\s\\S]*main\\.min\\.[0-9a-f]+\\.js",
+  # NOTE: the former "reading 'removeAttribute' ... main.min.<hash>.js" entry is
+  # gone. It suppressed a Hextra core/menu.js null-deref on the non-sidebar pages
+  # (homepage, /blog/ + posts, /docs/ landing, marketing): menu.js queries
+  # `.hextra-sidebar-container` / `.hextra-hamburger-menu` at DOMContentLoaded
+  # with no null guard. docs-theme-extras' docs-init.js now runs a top-level
+  # guard (during deferred execution, before DOMContentLoaded) that injects
+  # hidden stand-ins when those elements are absent, so menu.js finds them and
+  # never throws. Verified by the browser console-errors crawl (all non-sidebar
+  # pages pass with no allowlist), so there is nothing left to suppress. The
+  # guard wins even though Hextra's main.min.js loads before docs-init.js in the
+  # <head>, because menu.js only touches the DOM in its DOMContentLoaded handler.
 ]

--- a/.github/workflows/framework-tests.yml
+++ b/.github/workflows/framework-tests.yml
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  framework-test-static:
+  framework-test:
     name: Static + content checks
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -128,6 +128,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: framework-test-static-report
+          name: framework-test-report
           path: docs-theme-extras/playwright-report
           retention-days: 7

--- a/.github/workflows/framework-tests.yml
+++ b/.github/workflows/framework-tests.yml
@@ -13,6 +13,11 @@ name: Framework tests
 on:
   pull_request:
     paths:
+      # Content — so the `content` scanners run on content-only PRs.
+      - 'content/**'
+      - 'assets/conrefs/**'
+      - 'assets/kgw-docs/**'
+      # Layout / build inputs.
       - 'layouts/**'
       - 'static/**'
       - 'assets/css/**'
@@ -26,7 +31,7 @@ on:
 
 jobs:
   framework-test-static:
-    name: Static checks
+    name: Static + content checks
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -92,18 +97,20 @@ jobs:
           # but isn't installed by default in this runner. Mirror the
           # install pattern from links.yml so Hugo can find it via npx.
           npm i -D postcss postcss-cli autoprefixer
-          hugo --gc --minify
+          # Capture the build log so hugo-warnings.spec can scan it for ERROR /
+          # WARN lines; surface it and fail if the build itself fails.
+          hugo --gc --minify > .build.log 2>&1 || { cat .build.log; exit 1; }
 
       - name: Install harness dependencies
         working-directory: docs-theme-extras
         run: npm ci
 
-      - name: Run static specs
+      - name: Run static + content specs
         working-directory: docs-theme-extras
         env:
           DOCS_TEST_CONFIG: ${{ github.workspace }}/.docs-test.toml
         run: |
-          npx playwright test --project=static --reporter=list,html 2>&1 | tee playwright-output.txt
+          npx playwright test --project=static --project=content --reporter=list,html 2>&1 | tee playwright-output.txt
 
       - name: Append summary to PR check
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,17 @@ framework-test-static:  ## Build, then run only the static (no-browser) specs â€
 		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test --project=static; \
 		result=$$?; npx playwright show-report; exit $$result)
 
+# Build the site and run only the content specs â€” author-side lints and
+# rendered-HTML integrity against the built content tree (no browser).
+.PHONY: framework-test-content
+framework-test-content:  ## Build, then run only the content specs
+	@$(MAKE) _framework_test_preflight
+	rm -rf public
+	hugo160 --gc --minify > .build.log 2>&1
+	cd $(FRAMEWORK_EXTRAS_DIR) && \
+		(DOCS_TEST_CONFIG=$(abspath ./.docs-test.toml) npx playwright test --project=content; \
+		result=$$?; npx playwright show-report; exit $$result)
+
 # Build the site and run chromium browser specs (tabs, mermaid, theme
 # toggle, copy-md, console errors, viewport, contrast).
 .PHONY: framework-test-browser

--- a/assets/kgw-docs/pages/about/custom-resources.md
+++ b/assets/kgw-docs/pages/about/custom-resources.md
@@ -53,7 +53,7 @@ Review the kgateway resources that you use to bootstrap, configure, and customiz
 
 A {{< gloss "Gateway Extension" >}}GatewayExtension{{< /gloss >}} is a {{< reuse "/kgw-docs/snippets/kgateway.md" >}} Custom Resource that serves as a configuration bridge between {{< reuse "/kgw-docs/snippets/kgateway.md" >}} and external services that extend a Gateway's functionality. These external services provide additional capabilities like authentication (`extAuth`), rate limiting (`rateLimit`), and request processing (`extProc`). TrafficPolicies can then refer to the GatewayExtension with the external service that the policy needs to be enforced. For more information, see the [API docs]({{< link-hextra path="/reference/api/#gatewayextension" >}}).
 
-### {{< reuse "kgw-docs/snippets/gatewayparameters.md" >}}
+### {{< reuse "kgw-docs/snippets/gatewayparameters.md" >}} {#gatewayparameters}
 
 When you create a Gateway resource, a [default gateway proxy template](https://github.com/kgateway-dev/kgateway/blob/{{< reuse "kgw-docs/versions/github-branch.md" >}}{{< reuse "kgw-docs/versions/github-kgateway-deployment.md" >}}) is used to automatically spin up and bootstrap a gateway proxy deployment and service in your cluster. The template includes Envoy configuration that binds the gateway proxy deployment to the Gateway resource that you created. In addition, the settings in the {{< gloss "GatewayParameters" >}}{{< reuse "kgw-docs/snippets/gatewayparameters.md" >}}{{< /gloss >}} resource are used to configure the gateway proxy.
 
@@ -70,7 +70,7 @@ Kgateway uses the following custom resources to attach policies to routes and ga
 
 * {{< version include-if="2.1.x,2.0.x" >}}[**HTTPListenerPolicy**]({{< link-hextra path="/about/policies/httplistenerpolicy/" >}}){{< /version >}}{{< version include-if="2.2.x,2.3.x,2.4.x" >}}[**ListenerPolicy**]({{< link-hextra path="/about/policies/listenerpolicy/" >}}){{< /version >}}: Apply policies to all HTTP and HTTPS listeners. 
 
-### {{< reuse "kgw-docs/snippets/backend.md" >}}s
+### {{< reuse "kgw-docs/snippets/backend.md" >}}s {#backends}
 
 For workloads within your cluster, you can route incoming traffic to their Kubernetes Service. But what if you have external services such as static hostnames or AWS Lambda functions that you want to route traffic to?
 

--- a/assets/kgw-docs/pages/security/external-auth.md
+++ b/assets/kgw-docs/pages/security/external-auth.md
@@ -1,8 +1,10 @@
 Bring your own {{< gloss "External Authorization" >}}external authorization{{< /gloss >}} service to protect requests that go through your Gateway.
 
+{{< version exclude-if="2.0.x,2.1.x" >}}
 {{< callout >}}
 This guide covers gRPC-based external authorization services. For HTTP-based services, see the [HTTP guide]({{< link-hextra path="/security/extauth/byo-ext-auth-service/http/" >}}).
 {{< /callout >}}
+{{< /version >}}
 
 ## About external auth {#about}
 

--- a/assets/kgw-docs/pages/security/jwt/basic.md
+++ b/assets/kgw-docs/pages/security/jwt/basic.md
@@ -268,7 +268,7 @@ The following example uses Keycloak as the identity provider.
    | `jwks.remote.backendRef` | A reference to the Backend that fronts the JWKS server. The kgateway proxy uses this Backend to fetch the JWKS keys from Keycloak. Set `kind` to `Backend` and `group` to `gateway.kgateway.dev`. |
    | `jwks.remote.cacheDuration` | How long the gateway caches the fetched keys before it refreshes them. If omitted, the keys are cached for 5 minutes. |
 
-   For more information, see the [API docs]({{< link-hextra path="/reference/api/#remotejwks" >}}).
+   {{< version exclude-if="2.1.x" >}}For more information, see the [API docs]({{< link-hextra path="/reference/api/#remotejwks" >}}).{{< /version >}}
 
 ### JWT validation modes {#jwt-validation}
 

--- a/assets/kgw-docs/pages/setup/customize/gateway.md
+++ b/assets/kgw-docs/pages/setup/customize/gateway.md
@@ -13,7 +13,7 @@ Choose between the following options to customize your gateway proxy:
 
 {{< conditional-text include-if="envoy" >}}
 {{< callout type="info" >}}
-To change the default proxy template and inject your own Envoy configuration, use a {{< version include-if="2.1.x,2.2.x" >}}[self-managed gateway]({{< link-hextra path="/setup/selfmanaged/" >}}){{< /version >}}{{< version exclude-if="2.1.x,2.2.x" >}}[self-managed gateway]({{< link-hextra path="/setup/customize/selfmanaged/" >}}){{< /version >}} instead.
+To change the default proxy template and inject your own Envoy configuration, use a {{< version include-if="2.1.x,2.2.x" >}}[self-managed gateway]({{< link-hextra path="/setup/selfmanaged/" >}}){{< /version >}}{{< version include-if="2.0.x" >}}[self-managed gateway]({{< link-hextra path="/setup/customize/selfmanaged/" >}}){{< /version >}}{{< version exclude-if="2.0.x,2.1.x,2.2.x" >}}[self-managed gateway]({{< link-hextra path="/setup/customize/envoy/selfmanaged/" >}}){{< /version >}} instead.
 {{< /callout >}}
 {{< /conditional-text >}}
 

--- a/assets/kgw-docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
+++ b/assets/kgw-docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
@@ -237,39 +237,7 @@ Create an HTTP listener so that the gateway can route gRPC traffic. For more inf
 
 ## Create a GRPCRoute {#create-grpcroute}
 
-1. Create the GRPCRoute resource. Include the `grpc.reflection.v1alpha.ServerReflection` method to enable dynamic API exploration. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute){{< version exclude-if="2.0.x,2.1.x,2.2.x" >}}
-   
-   ```yaml
-   kubectl apply -f - <<EOF
-   apiVersion: gateway.networking.k8s.io/v1
-   kind: GRPCRoute
-   metadata:
-     name: grpc-echo-route
-     namespace: {{< reuse "kgw-docs/snippets/namespace.md" >}}
-     labels:
-       app: grpc-echo
-   spec:
-     parentRefs:
-     - name: grpc-gateway
-       namespace: {{< reuse "kgw-docs/snippets/namespace.md" >}}
-       sectionName: https
-     hostnames:
-     - "grpc.example.com"
-     rules:
-     - matches:
-       - method:
-           service: "grpc.reflection.v1alpha.ServerReflection"
-       backendRefs:
-       - name: grpc-echo-svc
-         namespace: default
-         port: 3000
-     - backendRefs:
-       - name: grpc-echo-svc
-         namespace: default
-         port: 3000
-   EOF
-   ```
-   {{< /version >}}{{< version include-if="2.0.x,2.1.x,2.2.x" >}}
+1. Create the GRPCRoute resource. Include the `grpc.reflection.v1alpha.ServerReflection` method to enable dynamic API exploration. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute).
 
    ```yaml
    kubectl apply -f - <<EOF
@@ -284,7 +252,7 @@ Create an HTTP listener so that the gateway can route gRPC traffic. For more inf
      parentRefs:
      - name: grpc-gateway
        namespace: {{< reuse "kgw-docs/snippets/namespace.md" >}}
-       sectionName: http
+       sectionName: {{< version exclude-if="2.0.x,2.1.x,2.2.x" >}}https{{< /version >}}{{< version include-if="2.0.x,2.1.x,2.2.x" >}}http{{< /version >}}
      hostnames:
      - "grpc.example.com"
      rules:
@@ -301,7 +269,6 @@ Create an HTTP listener so that the gateway can route gRPC traffic. For more inf
          port: 3000
    EOF
    ```
-   {{< /version >}}
 
 2. Verify that the GRPCRoute is applied successfully.
 

--- a/assets/kgw-docs/snippets/debug-gateway.md
+++ b/assets/kgw-docs/snippets/debug-gateway.md
@@ -1,6 +1,6 @@
 1. Make sure that the {{< reuse "/kgw-docs/snippets/kgateway.md" >}} control plane and gateway proxies are running. For any pod that is not running, describe the pod for more details.
    
-   ```she
+   ```sh
    kubectl get pods -n {{< reuse "kgw-docs/snippets/namespace.md" >}}
    ```
    

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.3 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.2 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.7 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.12 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.4 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.6 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.1 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/kgateway-dev/kgateway.dev
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.18-beta.5 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.18-beta.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.4 h1:C1kbPlAO6tP6vLNDGb0vksGT6MQpIerEaDZOOewIwfM=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.4/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.7 h1:Z1WWb9ZCoJymUkh3d1e9akfVX2aGOIUTdPoEH26XvcQ=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.7/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18 h1:S3CGkTq4EjIj1PNqQXht1xtLLGTUqhWzIezycV6wP3s=
+github.com/solo-io/docs-theme-extras v0.1.18/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.12 h1:GZtCI4bugkLmTXgG7a5vKgOq2MBw7pd0M1paA7y75yc=
-github.com/solo-io/docs-theme-extras v0.1.12/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.1 h1:+mg/3ip4xdhkiM2dKzEq9imho/IJfjJwHm54L9Duo00=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.3 h1:P/JgQy3VFC2H0l9yPab0JSEfjqEvldLmDFqfWLOo4rk=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.3/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.4 h1:C1kbPlAO6tP6vLNDGb0vksGT6MQpIerEaDZOOewIwfM=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.4/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.1 h1:+mg/3ip4xdhkiM2dKzEq9imho/IJfjJwHm54L9Duo00=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.2 h1:0ysAnOUg5FNPmG0IneEN7YJiDLHtYxf9b5cwrsaOjlY=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1Xk
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.7 h1:Z1WWb9ZCoJymUkh3d1e9akfVX2aGOIUTdPoEH26XvcQ=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.7/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.1.18-beta.2 h1:0ysAnOUg5FNPmG0IneEN7YJiDLHtYxf9b5cwrsaOjlY=
-github.com/solo-io/docs-theme-extras v0.1.18-beta.2/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.3 h1:P/JgQy3VFC2H0l9yPab0JSEfjqEvldLmDFqfWLOo4rk=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.3/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5 h1:gbCV0I0NB6z/k+qQTy0Dhl1XkswDwsxQPfZiM1Fniaw=
 github.com/solo-io/docs-theme-extras v0.1.18-beta.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.6 h1:+E0ZW1rmf8rnL3TaFgaIwW72HtCdJzuw1UEIdY2RPTc=
+github.com/solo-io/docs-theme-extras v0.1.18-beta.6/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=


### PR DESCRIPTION
# Description

Added framework content tests for better linting. Bumps `docs-theme-extras` to
`v0.1.18` and adopts the harness's renamed **`content`** Playwright project
(replacing the old **`smoke`** project), so content-only PRs now run the
rendered-markdown leak scan.

**What changed:**
- **Harness pin:** `docs-theme-extras` `v0.1.12` → `v0.1.18` (go.mod/go.sum).
- **Run `static` + `content`:** the framework-test job now runs
  `--project=static --project=content`; the `[checks] smoke/crossBrowser`
  toggles were removed (smoke folded into `content`; single-site repo doesn't
  need the cross-product scoping).
- **Content path filter:** the workflow's `pull_request.paths` now includes
  `content/**`, `assets/conrefs/**`, and `assets/kgw-docs/**` so the content
  scanners run on content-only PRs.
- **Hugo build-log scan:** builds now write `.build.log` (new `buildLog` in
  `.docs-test.toml`); `hugo-warnings.spec` scans it for ERROR/WARN lines. New
  `framework-test-content` Makefile target for local runs.
- **Content lint fixes** the new scanners surfaced: explicit heading anchors
  on reuse-shortcode headings (`{#gatewayparameters}`, `{#backends}`),
  `external-auth.md`, `jwt/basic.md`, `gateway.md`, `grpc-services.md`, and the
  `debug-gateway.md` snippet.

# Change Type
/kind fix

# Changelog
```release-note
NONE
```