### PR TITLE
docs: remove shield icon from OAuth section to match other sections

### DIFF
--- a/content/docs/envoy/latest/security/oauth/_index.md
+++ b/content/docs/envoy/latest/security/oauth/_index.md
@@ -1,6 +1,5 @@
 ---
 title: OAuth
-icon: security
 weight: 60
 description: Configure OAuth2/OIDC authentication with advanced features.
 ---


### PR DESCRIPTION
# Description

Removes the shield icon from the OAuth section (`content/docs/envoy/latest/security/oauth/_index.md`) to match other security subsections like JWT and ExtAuth.

- **Motivation:** The shield icon was present in the OAuth section, but other subsections do not have icons.
- **What changed:** Removed the `icon: security` line from the frontmatter.

# Change Type

/kind documentation

# Changelog

```release-note
docs: remove shield icon from OAuth section
