### PR TITLE
docs: remove duplicate Keycloak card from OAuth2/OIDC landing page

### DIFF
--- a/content/docs/envoy/2.2.x/security/oauth2/_index.md
+++ b/content/docs/envoy/2.2.x/security/oauth2/_index.md
@@ -5,7 +5,3 @@ description: Protect routes with browser-based OAuth2/OIDC login flows backed by
 ---
 
 kgateway has built-in support for the OAuth2 authorization code flow. Point a `GatewayExtension` at your provider, attach it to a route via `TrafficPolicy`, and the gateway handles the rest - login redirects, token exchange, and session cookies - without touching your upstream service.
-
-{{< cards >}}
-  {{< card link="keycloak" title="Keycloak" >}}
-{{< /cards >}}

--- a/content/docs/envoy/latest/security/oauth2/_index.md
+++ b/content/docs/envoy/latest/security/oauth2/_index.md
@@ -5,7 +5,3 @@ description: Protect routes with browser-based OAuth2/OIDC login flows backed by
 ---
 
 kgateway has built-in support for the OAuth2 authorization code flow. Point a `GatewayExtension` at your provider, attach it to a route via `TrafficPolicy`, and the gateway handles the rest - login redirects, token exchange, and session cookies - without touching your upstream service.
-
-{{< cards >}}
-  {{< card link="keycloak" title="Keycloak" >}}
-{{< /cards >}}

--- a/content/docs/envoy/main/security/oauth2/_index.md
+++ b/content/docs/envoy/main/security/oauth2/_index.md
@@ -5,7 +5,3 @@ description: Protect routes with browser-based OAuth2/OIDC login flows backed by
 ---
 
 kgateway has built-in support for the OAuth2 authorization code flow. Point a `GatewayExtension` at your provider, attach it to a route via `TrafficPolicy`, and the gateway handles the rest - login redirects, token exchange, and session cookies - without touching your upstream service.
-
-{{< cards >}}
-  {{< card link="keycloak" title="Keycloak" >}}
-{{< /cards >}}


### PR DESCRIPTION
# Description

This PR removes the duplicate Keycloak card from the OAuth2/OIDC landing page.

- **Motivation:** The landing page currently shows two Keycloak cards, which is confusing for users.
- **What changed:** Removed the duplicate Keycloak card from `_index.md`.
- **Related issues:** N/A

# Change Type

/kind fix
/kind documentation

# Changelog

```release-note
docs: remove duplicate Keycloak card from OAuth2/OIDC landing page