### PR TITLE
URL fix

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -54,21 +54,29 @@ jobs:
           python3 -c "
           import yaml
           import json
-          
+          import sys
+
           with open('hugo.yaml', 'r') as f:
               config = yaml.safe_load(f)
-          
+
           versions = config.get('params', {}).get('versions', [])
           version_data = []
-          
+
+          # linkVersion is the version's URL path segment, so it is also the
+          # directory segment generate-ref-docs.py writes API docs into
+          # (content/docs/envoy/<linkVersion>/reference/). There is no separate
+          # 'url' field: it used to duplicate linkVersion, and dropping it from
+          # hugo.yaml silently emptied the path segment here.
           for version in versions:
-              version_info = {
+              link_version = (version.get('linkVersion') or '').strip('/')
+              if not link_version:
+                  print(f'Error: entry {version.get(\"version\")!r} in hugo.yaml has no linkVersion', file=sys.stderr)
+                  sys.exit(1)
+              version_data.append({
                   'version': version.get('version'),
-                  'linkVersion': version.get('linkVersion'),
-                  'url': version.get('url', '').lstrip('/')
-              }
-              version_data.append(version_info)
-          
+                  'linkVersion': link_version,
+              })
+
           print(json.dumps(version_data))
           " > versions.json
           
@@ -119,10 +127,10 @@ jobs:
             - Control plane metrics documentation
             - Each version uses the latest corresponding tag from the kgateway repository
 
-            **File locations:**
-            - API docs: `content/docs/envoy/{VERSION}/reference/api.md`
+            **File locations:** `{LINK_VERSION}` is the URL path segment (`main`, `latest`, `2.3.x`), `{VERSION}` is the version family (`2.5.x`, `2.4.x`).
+            - API docs: `content/docs/envoy/{LINK_VERSION}/reference/api.md`
             - Helm docs: `assets/kgw-docs/pages/reference/helm/{VERSION}/` (included in content pages via `reuse` shortcode)
-            - Metrics docs: `assets/kgw-docs/snippets/{VERSION}/metrics-control-plane.md`
+            - Metrics docs: `assets/kgw-docs/snippets/{LINK_VERSION}/metrics-control-plane.md`
           branch: api-gen-update
           delete-branch: true
           base: main

--- a/scripts/generate-ref-docs.py
+++ b/scripts/generate-ref-docs.py
@@ -630,10 +630,14 @@ def _post_process_api_docs(api_file):
         f.write(content)
 
 
-def generate_api_docs(version, link_version, url_path, kgateway_dir='kgateway'):
-    '''Generate API reference documentation'''
+def generate_api_docs(version, link_version, kgateway_dir='kgateway'):
+    '''Generate API reference documentation
+
+    link_version doubles as the directory segment under content/docs/envoy/,
+    since that segment is the version's URL path segment (main, latest, 2.3.x).
+    '''
     print(f'  → Generating API docs for version {version}')
-    
+
     # Check if the API directory exists
     api_path = f'{kgateway_dir}/api/v1alpha1/'
     if not os.path.exists(api_path):
@@ -679,7 +683,7 @@ def generate_api_docs(version, link_version, url_path, kgateway_dir='kgateway'):
         # Extract gateway.kgateway.dev/v1alpha1 package
         envoy_content = extract_package_section(generated_content, 'gateway.kgateway.dev/v1alpha1')
         if envoy_content:
-            target_path = f'content/docs/envoy/{url_path}/reference/'
+            target_path = f'content/docs/envoy/{link_version}/reference/'
             os.makedirs(target_path, exist_ok=True)
             api_file = f'{target_path}api.md'
             
@@ -712,7 +716,7 @@ def generate_api_docs(version, link_version, url_path, kgateway_dir='kgateway'):
         print(f'    Version {version} uses unified API - generating docs for envoy')
         
         for doc_dir in ['envoy']:
-            target_path = f'content/docs/{doc_dir}/{url_path}/reference/'
+            target_path = f'content/docs/{doc_dir}/{link_version}/reference/'
             os.makedirs(target_path, exist_ok=True)
             
             api_file = f'{target_path}api.md'
@@ -767,7 +771,7 @@ def _generate_shared_types(api_file, kgateway_dir='kgateway'):
         print(f'    Warning: generate-shared-types failed: {e}')
 
 
-def generate_helm_docs(version, link_version, url_path, kgateway_dir='kgateway'):
+def generate_helm_docs(version, link_version, kgateway_dir='kgateway'):
     '''Generate Helm chart reference documentation'''
     print(f'  → Generating Helm docs for version {version}')
     
@@ -871,7 +875,7 @@ def generate_helm_docs(version, link_version, url_path, kgateway_dir='kgateway')
     return generated_any
 
 
-def generate_metrics_docs(version, link_version, url_path, kgateway_dir='kgateway'):
+def generate_metrics_docs(version, link_version, kgateway_dir='kgateway'):
     '''Generate control plane metrics documentation'''
     print(f'  → Generating metrics docs for version {version}')
     
@@ -943,10 +947,17 @@ def main():
     
     for version_info in versions:
         version = version_info['version']
-        link_version = version_info['linkVersion']
-        url_path = version_info['url']
-        
-        print(f'\n🔄 Processing version: {version} (linkVersion: {link_version}, path: {url_path})')
+        link_version = (version_info.get('linkVersion') or '').strip('/')
+
+        # linkVersion is the directory segment API docs are written into. An
+        # empty one would collapse content/docs/envoy/<seg>/reference/ down to
+        # content/docs/envoy/reference/, where every version overwrites the
+        # same file and no real version tree gets updated. Fail loudly instead.
+        if not link_version:
+            print(f'❌ Version {version} has no linkVersion in versions.json')
+            sys.exit(1)
+
+        print(f'\n🔄 Processing version: {version} (linkVersion: {link_version})')
         
         # Resolve tag or branch based on trigger type
         if is_release_trigger:
@@ -977,19 +988,19 @@ def main():
         success_count = 0
         
         try:
-            if generate_api_docs(version, link_version, url_path):
+            if generate_api_docs(version, link_version):
                 success_count += 1
         except Exception as e:
             print(f'   ⚠ API docs failed: {e}')
         
         try:
-            if generate_helm_docs(version, link_version, url_path):
+            if generate_helm_docs(version, link_version):
                 success_count += 1
         except Exception as e:
             print(f'   ⚠ Helm docs failed: {e}')
         
         try:
-            if generate_metrics_docs(version, link_version, url_path):
+            if generate_metrics_docs(version, link_version):
                 success_count += 1
         except Exception as e:
             print(f'   ⚠ Metrics docs failed: {e}')

--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,1 @@
-[{"version": "2.5.x", "linkVersion": "main", "url": "main"}, {"version": "2.4.x", "linkVersion": "latest", "url": "latest"}, {"version": "2.3.x", "linkVersion": "2.3.x", "url": "2.3.x"}, {"version": "2.2.x", "linkVersion": "2.2.x", "url": "2.2.x"}, {"version": "2.1.x", "linkVersion": "2.1.x", "url": "2.1.x"}]
+[{"version": "2.5.x", "linkVersion": "main"}, {"version": "2.4.x", "linkVersion": "latest"}, {"version": "2.3.x", "linkVersion": "2.3.x"}, {"version": "2.2.x", "linkVersion": "2.2.x"}, {"version": "2.1.x", "linkVersion": "2.1.x"}]


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
`url` was pure duplication. In every entry it was just "/" + linkVersion,
and nothing in the theme reads it, not kgw's local partials and not docs-theme-extras.
Both build version links from linkVersion. So it was removed from hugo.yaml.

What was missed is that the reference-docs automation was the one real consumer, and it
used `url` as a directory path segment:
```
  update-api-docs.yml:68  ->  'url': version.get('url', '').lstrip('/')   # now ""
  generate-ref-docs.py    ->  content/docs/envoy/{url}/reference/api.md
```
With it empty, the path collapses to `content/docs/envoy/reference/api.md`, so all five
versions write the same file and clobber each other, and the real per-version trees get
no update at all. 

With this PR, the workflow now emits `linkVersion` instead of `url`, the script uses it
as the path segment, and there's a guard so an empty segment fails the run loudly instead
of silently writing to a collapsed path. Helm and metrics were never affected, they key
off `version` and `linkVersion` respectively.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
