### PR TITLE
fix: sync .docs-test.toml versions with versions.json and add regression test

### DIFF
--- a/.docs-test.toml
+++ b/.docs-test.toml
@@ -44,7 +44,7 @@ scanRoots = [
 # that don't match the regex.
 [versioning]
 versionFromPath = "^/docs/(?:envoy|agentgateway)/(?<version>[^/]+)/"
-versions        = ["main", "latest", "2.2.x", "2.1.x", "2.0.x"]
+versions        = ["main", "latest", "2.3.x", "2.2.x", "2.1.x"]
 
 # Allowlists for known-benign noise that surfaces against real product
 # content (test fixture has none of this). Tighten as content is fixed.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -66,7 +66,6 @@ jobs:
 
           LYCHEE_COMMON=(lychee
             --verbose
-            --exclude-path public/docs/envoy/2.0.x
             --config docs-link-checking/lychee.toml
             --root-dir "${{ github.workspace }}/public"
             --index-files index.html

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -6,12 +6,16 @@ on:
     paths:
       - "scripts/**"
       - ".github/workflows/scripts-tests.yml"
+      - ".docs-test.toml"
+      - "versions.json"
   push:
     branches:
       - main
     paths:
       - "scripts/**"
       - ".github/workflows/scripts-tests.yml"
+      - ".docs-test.toml"
+      - "versions.json"
 
 jobs:
   python-unit-tests:

--- a/scripts/tests/test_version_config.py
+++ b/scripts/tests/test_version_config.py
@@ -1,0 +1,40 @@
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docs_test_toml_versions_match_active_versions():
+    """Verify that .docs-test.toml [versioning].versions matches versions.json.
+
+    The Playwright testing harness in solo-io/docs-theme-extras relies on
+    .docs-test.toml to determine which version trees to scan. If an active
+    version is missing from .docs-test.toml, its documentation is silently
+    skipped by CI framework testing.
+    """
+    versions_json_path = REPO_ROOT / "versions.json"
+    assert versions_json_path.exists(), "versions.json does not exist"
+    active_versions = json.loads(versions_json_path.read_text(encoding="utf-8"))
+    expected_link_versions = [v["linkVersion"] for v in active_versions]
+
+    docs_test_path = REPO_ROOT / ".docs-test.toml"
+    assert docs_test_path.exists(), ".docs-test.toml does not exist"
+    content = docs_test_path.read_text(encoding="utf-8")
+
+    match = re.search(r"\[versioning\][\s\S]*?versions\s*=\s*\[(.*?)\]", content)
+    assert match, "Could not find [versioning].versions in .docs-test.toml"
+
+    actual_versions = [
+        s.strip().strip('"\'')
+        for s in match.group(1).split(",")
+        if s.strip()
+    ]
+
+    assert actual_versions == expected_link_versions, (
+        f".docs-test.toml [versioning].versions does not match active versions in versions.json.\n"
+        f"Configured: {actual_versions}\n"
+        f"Expected:   {expected_link_versions}\n"
+        f"Missing:    {[v for v in expected_link_versions if v not in actual_versions]}\n"
+        f"Obsolete:   {[v for v in actual_versions if v not in expected_link_versions]}"
+    )

--- a/scripts/tests/test_version_config.py
+++ b/scripts/tests/test_version_config.py
@@ -6,11 +6,18 @@ nothing tied the two together, so the lists silently diverged: `2.3.x` shipped
 without ever being added, and a long-dead `2.0.x` stayed behind. This test is
 the tie.
 
-The drift was not caught sooner because the framework-tests workflow still runs
-with `continue-on-error: true`. The spec that asserts every configured version
-appears in the version dropdown did fail on the phantom `2.0.x` — the job just
-did not report it. Keep that in mind before relying on this test alone: it only
-blocks a merge while `scripts-tests` is a required check.
+Nothing in CI could have caught this, which is why the check belongs here. The
+framework-tests workflow runs only the harness's `static` and `content`
+projects. The spec that asserts every configured version appears in the version
+dropdown lives in the `browser` project, which that workflow never invokes. The
+`static` specs that do read this list — auto-cards, card-image, custom-alert —
+either generate no tests at all or skip outright when pointed at a consumer's
+own build rather than the harness fixture. The drift was invisible by
+construction, not merely unreported.
+
+One caveat before relying on this test: it only blocks a merge while
+`scripts-tests` is a required check, and as of this commit the `main` ruleset
+requires only `DCO`.
 '''
 
 import json

--- a/scripts/tests/test_version_config.py
+++ b/scripts/tests/test_version_config.py
@@ -1,5 +1,20 @@
+'''Guards `.docs-test.toml` against drifting away from `versions.json`.
+
+`versions.json` is the single source of truth for which doc versions this repo
+builds. `.docs-test.toml` repeats that list for the Playwright harness, and
+nothing tied the two together, so the lists silently diverged: `2.3.x` shipped
+without ever being added, and a long-dead `2.0.x` stayed behind. This test is
+the tie.
+
+The drift was not caught sooner because the framework-tests workflow still runs
+with `continue-on-error: true`. The spec that asserts every configured version
+appears in the version dropdown did fail on the phantom `2.0.x` — the job just
+did not report it. Keep that in mind before relying on this test alone: it only
+blocks a merge while `scripts-tests` is a required check.
+'''
+
 import json
-import re
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -9,9 +24,10 @@ def test_docs_test_toml_versions_match_active_versions():
     """Verify that .docs-test.toml [versioning].versions matches versions.json.
 
     The Playwright testing harness in solo-io/docs-theme-extras relies on
-    .docs-test.toml to determine which version trees to scan. If an active
-    version is missing from .docs-test.toml, its documentation is silently
-    skipped by CI framework testing.
+    .docs-test.toml to decide which version trees the per-version specs
+    synthesize URLs for. A version missing from the list is never checked by
+    those specs; a version present but not built makes them chase pages that
+    do not exist.
     """
     versions_json_path = REPO_ROOT / "versions.json"
     assert versions_json_path.exists(), "versions.json does not exist"
@@ -20,21 +36,25 @@ def test_docs_test_toml_versions_match_active_versions():
 
     docs_test_path = REPO_ROOT / ".docs-test.toml"
     assert docs_test_path.exists(), ".docs-test.toml does not exist"
-    content = docs_test_path.read_text(encoding="utf-8")
+    config = tomllib.loads(docs_test_path.read_text(encoding="utf-8"))
 
-    match = re.search(r"\[versioning\][\s\S]*?versions\s*=\s*\[(.*?)\]", content)
-    assert match, "Could not find [versioning].versions in .docs-test.toml"
+    versioning = config.get("versioning")
+    assert versioning is not None, "[versioning] table is missing from .docs-test.toml"
+    actual_versions = versioning.get("versions")
+    assert actual_versions is not None, (
+        "[versioning].versions is missing from .docs-test.toml"
+    )
 
-    actual_versions = [
-        s.strip().strip('"\'')
-        for s in match.group(1).split(",")
-        if s.strip()
-    ]
-
+    # ORDER IS PART OF THE CONTRACT. Do not relax this to a set or a sorted
+    # comparison because the "Missing"/"Obsolete" wording below reads like a set
+    # difference. The harness treats `versions[0]` as the version its dropdown
+    # navigation test clicks through to, so `versions.json` order (newest first,
+    # `main` then `latest`) has to survive into `.docs-test.toml` verbatim.
     assert actual_versions == expected_link_versions, (
         f".docs-test.toml [versioning].versions does not match active versions in versions.json.\n"
         f"Configured: {actual_versions}\n"
         f"Expected:   {expected_link_versions}\n"
         f"Missing:    {[v for v in expected_link_versions if v not in actual_versions]}\n"
-        f"Obsolete:   {[v for v in actual_versions if v not in expected_link_versions]}"
+        f"Obsolete:   {[v for v in actual_versions if v not in expected_link_versions]}\n"
+        f"Order:      {'differs' if sorted(actual_versions) == sorted(expected_link_versions) else 'n/a'}"
     )


### PR DESCRIPTION
Closes #977

## What

`.docs-test.toml` had a stale `[versioning].versions` list — `2.3.x` was missing and obsolete `2.0.x` was still there. This meant the Playwright framework tests in CI silently skipped every page under `/docs/envoy/2.3.x/`.

## Why

The file was introduced in `7ca74886` (2026-05-27) with versions copied from a pre-2.3 state of `versions.json`. The 2.3 release had already landed 8 days earlier, but nobody noticed because the harness just quietly skips versions it doesn't recognize — no error, no warning.

## Changes

- **`.docs-test.toml`** — updated versions from `["main", "latest", "2.2.x", "2.1.x", "2.0.x"]` to `["main", "latest", "2.3.x", "2.2.x", "2.1.x"]`
- **`.github/workflows/links.yml`** — removed dead `--exclude-path public/docs/envoy/2.0.x` (that version isn't built anymore)
- **`scripts/tests/test_version_config.py`** — new regression test that asserts `.docs-test.toml` versions match `versions.json`, so this can't silently drift again
- **`.github/workflows/scripts-tests.yml`** — added `.docs-test.toml` and `versions.json` to the trigger paths so the test runs automatically when either file changes

## Verification

```
$ python -m pytest scripts/tests/ -v
27 passed in 1.13s
```

The new test was also verified to fail correctly before the fix:

```
AssertionError: .docs-test.toml [versioning].versions does not match active versions in versions.json.
  Configured: ['main', 'latest', '2.2.x', '2.1.x', '2.0.x']
  Expected:   ['main', 'latest', '2.3.x', '2.2.x', '2.1.x']
  Missing:    ['2.3.x']
  Obsolete:   ['2.0.x']
```