### PR TITLE
docs: fix incorrect Docker command syntax in blog post

### DIFF
--- a/content/blog/securing-egress-traffic-with-kgateway-istio-ambient-mesh-and-kyverno-lfx-mentorship-blog.md
+++ b/content/blog/securing-egress-traffic-with-kgateway-istio-ambient-mesh-and-kyverno-lfx-mentorship-blog.md
@@ -88,9 +88,9 @@ Before integrating kgateway with Istio Ambient, ensure we have:
 3. Set up an ambient mesh in your cluster to secure service-to-service communication with mutual TLS by following the [ambientmesh.io](https://ambientmesh.io/docs/quickstart/) quickstart documentation.
 4. Deploy the Ollama Container at port number 11434, binding to 0.0.0.0 so the Kubernetes virtual machine can access it via the host's bridge network.
    ```
-   docker run -d -v ollama:/root/.ollama -p 11434:11434 -e OLLAMA_HOST=0.0.0.0 ollama/ollama --name ollama-server
+   docker run -d --name ollama-server -v ollama:/root/.ollama -p 11434:11434 -e OLLAMA_HOST=0.0.0.0 ollama/ollama
    ```
-5. Get the Container IP of ollama container which will be inserted at all the **`address fields` which is 172.17.0.2 in our case.
+5. Get the Container IP of ollama container which will be inserted at all the **`address fields`** which is 172.17.0.2 in our case.
    ```
    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <CONTAINER_NAME>
    ```


### PR DESCRIPTION
## Description

Fix incorrect Docker command syntax and broken markdown formatting in the blog post
"Securing Egress Traffic with kgateway, Istio Ambient Mesh, and Kyverno."

## What changed

1. **Docker command fix (line 91):** Moved `--name ollama-server` flag before the image name
   `ollama/ollama`. In Docker CLI syntax, all options must precede the image name — anything
   after it is interpreted as the container's entrypoint command, causing the original command
   to fail with `exec: "--name": executable file not found in $PATH`.

2. **Markdown fix (line 93):** Closed the unclosed bold (`**`) marker around `` `address fields` ``
   so the formatting renders correctly.

## Related issues

Fixes #751

## Change Type

/kind documentation

## Changelog

NONE